### PR TITLE
Add build option to keep or remove unreferenced assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
 *.s[mf]c
+*.swp
 *.sym
 data/*

--- a/build_rom.bat
+++ b/build_rom.bat
@@ -5,7 +5,6 @@ echo Creating FF file
 python tools/ff_file.py ../SM.sfc
 
 echo Patching FF file with asar
-cd tools
-asar --no-title-check --symbols=wla --symbols-path=../symbols.sym ../src/main.asm ../SM.sfc && echo Success!
+"tools/asar" --no-title-check --symbols=wla --symbols-path=symbols.sym %* src/main.asm SM.sfc && echo Success!
 
 PAUSE

--- a/build_rom.sh
+++ b/build_rom.sh
@@ -4,5 +4,4 @@ echo "Creating FF file"
 python3 tools/ff_file.py ../SM.sfc
 
 echo "Patching FF file with asar"
-cd tools
-./asar-standalone --no-title-check --symbols=wla --symbols-path=../symbols.sym ../src/main.asm ../SM.sfc && echo Success!
+./tools/asar-standalone --no-title-check --symbols=wla --symbols-path=symbols.sym $@ src/main.asm SM.sfc && echo Success!

--- a/create_data.bat
+++ b/create_data.bat
@@ -1,5 +1,8 @@
 
 @echo off
 
+set "sfc_src=Super Metroid.sfc"
+if "%~1" neq "" set "sfc_src=%~1"
+
 echo Extracting assets from original ROM
-python tools/rip_assets.py "Super Metroid.sfc" -o data || PAUSE
+python tools/rip_assets.py "%sfc_src%" -o data || PAUSE

--- a/create_data.sh
+++ b/create_data.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+sfc_src="Super Metroid.sfc"
+if [ $# -ne 0 ]; then
+    sfc_src="$@"
+fi
+
 echo "Extracting assets from original ROM"
-python3 tools/rip_assets.py "Super Metroid.sfc" -o data
+python3 tools/rip_assets.py "${sfc_src}" -o data

--- a/src/bank_80.asm
+++ b/src/bank_80.asm
@@ -299,6 +299,7 @@ SetBossBitsInAForCurrentArea:
     RTL                                                                  ;8081BF;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ClearBossBitsInAForCurrentArea_8081C0:
     PHX                                                                  ;8081C0;
     PHY                                                                  ;8081C1;
@@ -314,6 +315,7 @@ UNUSED_ClearBossBitsInAForCurrentArea_8081C0:
     PLY                                                                  ;8081D9;
     PLX                                                                  ;8081DA;
     RTL                                                                  ;8081DB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckIfBossBitsForCurrentAreaMatchAnyBitsInA:
@@ -600,6 +602,7 @@ ClearForceBlankAndWaitForNMI:
     RTL                                                                  ;808394;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_UpdateCGRAM_808395:
     PHP                                                                  ;808395;
     SEP #$10                                                             ;808396;
@@ -673,6 +676,7 @@ UNUSED_WriteYBytesOfATo_7E0000_X_8bit_8083E3:
     PLB                                                                  ;8083F3;
     PLP                                                                  ;8083F4;
     RTL                                                                  ;8083F5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 WriteYBytesOfATo_7E0000_X_16bit:
@@ -885,6 +889,7 @@ Crash_Handler:
     JML.L Crash_Handler                                                  ;808573; Crash handler, jump to self
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_WaitAFrames_808577:
     PHP                                                                  ;808577;
     PHB                                                                  ;808578;
@@ -900,6 +905,7 @@ UNUSED_WaitAFrames_808577:
     PLB                                                                  ;808589;
     PLP                                                                  ;80858A;
     RTL                                                                  ;80858B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 LoadMirrorOfCurrentAreasMapExplored:
@@ -927,8 +933,10 @@ LoadMirrorOfCurrentAreasMapExplored:
     RTL                                                                  ;8085B5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Generic_Bitmasks:
     dw $0001,$0002,$0004,$0008,$0010,$0020,$0040,$0080                   ;8085B6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 MirrorCurrentAreasMapExplored:
     PHP                                                                  ;8085C6;
@@ -1278,6 +1286,7 @@ InitialisePPURegisters:
     RTS                                                                  ;8088B3;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ClearHighRAM_8088B4:
     REP #$30                                                             ;8088B4;
     LDA.W #$0000                                                         ;8088B6;
@@ -1290,6 +1299,7 @@ UNUSED_ClearHighRAM_8088B4:
     JSL.L WriteYBytesOfATo_7F0000_X_16bit                                ;8088CA;
     SEP #$30                                                             ;8088CE;
     RTS                                                                  ;8088D0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 WriteALoadOf_1C2F:
@@ -2139,6 +2149,7 @@ HandleMusicQueue:
     RTL                                                                  ;808FA2;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_QueueMusicDataOrTrack_808FA3:
     PHP                                                                  ;808FA3;
     REP #$30                                                             ;808FA4;
@@ -2157,6 +2168,7 @@ UNUSED_QueueMusicDataOrTrack_808FA3:
     PLX                                                                  ;808FBE;
     PLP                                                                  ;808FBF;
     RTL                                                                  ;808FC0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 QueueMusicDataOrTrack_8FrameDelay:
@@ -4485,6 +4497,7 @@ DisplayViewablePartOfRoom:
     RTL                                                                  ;80A1E2;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_QueueClearingOfBG2Tilemap_80A1E3:
     LDX.W #$0FFE                                                         ;80A1E3;
     LDA.W #$0338                                                         ;80A1E6;
@@ -4508,6 +4521,7 @@ UNUSED_QueueClearingOfBG2Tilemap_80A1E3:
     ADC.W #$0007                                                         ;80A20A;
     STA.W $0330                                                          ;80A20D;
     RTL                                                                  ;80A210;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 QueueClearingOfFXTilemap:
@@ -6347,6 +6361,7 @@ DoorTransitionScrolling_Up:
     RTS                                                                  ;80B031;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SetupRotatingMode7Background_80B032:
     LDA.W #$0001                                                         ;80B032;
     STA.W $0783                                                          ;80B035;
@@ -6450,6 +6465,7 @@ UNUSED_ConfigureMode7RotationMatrix_80B0C2:
 .return:
     PLP                                                                  ;80B0FD;
     RTL                                                                  ;80B0FE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Decompression_HardcodedDestination:

--- a/src/bank_81.asm
+++ b/src/bank_81.asm
@@ -1456,8 +1456,10 @@ Debug_GameOverMenu_Index1_Initialise:
     RTS                                                                  ;818DA3;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_818DA4:
     dw $000F                                                             ;818DA4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Debug_GameOverMenu_Index24_FadeIn:
     REP #$30                                                             ;818DA6;
@@ -2288,8 +2290,10 @@ Initialise_FileSelectMenu_FileCopy:
     RTS                                                                  ;819590;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30_819591:
     REP #$30                                                             ;819591;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SetInitial_FileCopyClear_MenuSelection:
     LDA.W $0954                                                          ;819593;
@@ -4072,8 +4076,10 @@ FileSelectMap_Index1_GameOptionsToAreaSelectMap_FadeOut:
     RTS                                                                  ;81A3D0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30_81A3D1:
     REP #$30                                                             ;81A3D1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LoadActiveAreaMapForegroundColors:
     TXA                                                                  ;81A3D3;
@@ -5396,8 +5402,10 @@ FileSelectMap_IndexA_RoomSelectMap:
     RTS                                                                  ;81AEC7;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30_81AEC8:
     REP #$30                                                             ;81AEC8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Handle_FileSelectMap_ScrollArrows:
     PHP                                                                  ;81AECA;

--- a/src/bank_82.asm
+++ b/src/bank_82.asm
@@ -1389,12 +1389,14 @@ GameState_27_EndingAndCredits:
     RTS                                                                  ;828B17;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_IncrementGameState_828B18:
     PHP                                                                  ;828B18;
     REP #$30                                                             ;828B19;
     INC.W $0998                                                          ;828B1B;
     PLP                                                                  ;828B1E;
     RTS                                                                  ;828B1F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 GameState_7_MainGameplayFadingIn:
@@ -4250,6 +4252,7 @@ Clear_PauseMenu_Data:
     RTS                                                                  ;82A3D8;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Change_Pose_Due_to_Equipment_Change:
     PHP                                                                  ;82A3D9;
     REP #$30                                                             ;82A3DA;
@@ -4261,6 +4264,7 @@ UNUSED_Change_Pose_Due_to_Equipment_Change:
     JSL.L LoadSamusSuitPalette                                           ;82A3E7;
     PLP                                                                  ;82A3EB;
     RTS                                                                  ;82A3EC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 .pointers:
@@ -4938,9 +4942,11 @@ Update_PauseMenu_L_R_Start_VRAMTilemap:
     RTS                                                                  ;82A87C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Draw_PauseScreen_SpriteAnimation_long:
     JSR.W Draw_PauseScreen_SpriteAnimation                               ;82A87D;
     RTL                                                                  ;82A880;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Draw_PauseScreen_SpriteAnimation:
@@ -6604,6 +6610,7 @@ EquipmentScreen_Main_ButtonResponse:
     RTS                                                                  ;82B5E7;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ConvertAToThreeDecimalDigits:
     PHP                                                                  ;82B5E8;
     REP #$30                                                             ;82B5E9;
@@ -6650,6 +6657,7 @@ UNUSED_ConvertAToThreeDecimalDigits:
 .return:
     PLP                                                                  ;82B629;
     RTS                                                                  ;82B62A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Draw_PauseMenu_during_FadeIn:
@@ -6677,6 +6685,7 @@ Draw_PauseMenu_during_FadeIn:
     RTL                                                                  ;82B64F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_82B650:
     PHP                                                                  ;82B650;
     PHB                                                                  ;82B651;
@@ -6698,6 +6707,7 @@ UNUSED_82B650:
     PLB                                                                  ;82B66F;
     PLP                                                                  ;82B670;
     RTL                                                                  ;82B671;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Draw_Map_Icons:
@@ -7108,8 +7118,10 @@ Draw_MapScrollArrow_and_Check_Scroll_in_that_Direction:
     RTL                                                                  ;82B931;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30_82B932:
     REP #$30                                                             ;82B932;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Handle_MapScrollArrows:
     PHP                                                                  ;82B934;
@@ -7630,6 +7642,7 @@ Queue_Samus_Movement_SoundEffects:
     RTL                                                                  ;82BE59;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_82BE5A:
     REP #$30                                                             ;82BE5A;
     LDA.W $079F                                                          ;82BE5C;
@@ -7735,6 +7748,7 @@ UNUSED_82BEA3:
 
 .crash:
     BRA .crash                                                           ;82BF02;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 ReserveTank_TransferEnergyPerFrame:
@@ -7797,8 +7811,10 @@ EquipmentScreenTilemaps:
 ; oSPRING BALL
     dw $08FF,$0910,$0911,$0912,$0913,$0914,$0915,$0916,$08D4             ;82BFAC;
 
+if !FEATURE_KEEP_UNREFERENCED
   .UNUSED
     dw $0000                                                             ;82BFBE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
   .screwAttack
 ; oSCREW ATTACK
@@ -8564,8 +8580,10 @@ Dummy_Samus_Wireframe_Tilemap:
 AreaSelect_SpritemapBaseIndex:
     dw $0038                                                             ;82C749;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DPadIcon_SpritemapIndex:
     dw $0044                                                             ;82C74B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Map_Elevator_Destinations:
     dw SpritemapIndices_crateria                                         ;82C74D;
@@ -11332,6 +11350,7 @@ DoorTransitionFunction_WaitForMusicQueueClear_and_LoadMusic:
     RTS                                                                  ;82E674;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DoorTransitionFunction:
     JSL.L HandleMusicQueue                                               ;82E675;
     JSL.L Determine_Which_Enemies_to_Process                             ;82E679;
@@ -11349,6 +11368,7 @@ UNUSED_DoorTransitionFunction:
 
 .return:
     RTS                                                                  ;82E6A1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DoorTransitionFunction_NudgeSamusIfInterceptingTheDoor:
@@ -13294,6 +13314,7 @@ PreInstruction_BorderAround_SPECIAL_SETTING_MODE:
     RTS                                                                  ;82F403;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PreInstruction_82F404:
     LDA.W $0DE2                                                          ;82F404;
     CMP.W #$0001                                                         ;82F407;
@@ -13305,6 +13326,7 @@ UNUSED_PreInstruction_82F404:
 
 .return:
     RTS                                                                  ;82F418;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_FileSelectMenu_SamusHelmet:
@@ -13400,10 +13422,12 @@ GameOptionsMenu_Objects_MenuSelectionMissile_preInstruction:
 GameOptionsMenu_Objects_MenuSelectionMissile_instructionList:
     dw InstList_GameOptionsMenu_MenuSelectionMissile                     ;82F4BC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GameOptionsMenu_Objects_FileSelectMenuSamusHelmet_82F4BE:
     dw Setup_FileSelectMenu_SamusHelmet                                  ;82F4BE;
     dw PreInstruction_FileSelectMenu_SamusHelmet                         ;82F4C0;
     dw InstList_GameOptionsMenu_FileSelectMenu_SamusHelmet               ;82F4C2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 GameOptionsMenu_Objects_OPTION_MODE_Border:
     dw Setup_BorderAround_OPTION_MODE                                    ;82F4C4;

--- a/src/bank_83.asm
+++ b/src/bank_83.asm
@@ -613,9 +613,11 @@ FXHeader_FastPillarsSetup:
     dw $0000,$FFFF,$FFFF,$0000                                           ;8387DC;
     db $00,$04,$02,$1E,$02,$1F,$00,$00                                   ;8387E4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FXHeader_8387EC:
     dw $0000,$FFFF,$FFFF,$0000                                           ;8387EC;
     db $00,$04,$02,$1E,$02,$1F,$00,$00                                   ;8387F4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 FXHeader_MickeyMouse:
     dw $0000,$FFFF,$FFFF,$0000                                           ;8387FC;
@@ -2471,10 +2473,12 @@ Door_FastPillarsSetup_4:
     db $00,$04,$01,$06,$00,$00                                           ;839914;
     dw $8000,$0000                                                       ;83991A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Door_83991E:
     dw RoomHeader_FastPillarsSetup                                       ;83991E;
     db $00,$05,$0E,$06,$00,$00                                           ;839920;
     dw $8000,$0000                                                       ;839926;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Door_MickeyMouse_0:
     dw RoomHeader_FastPillarsSetup                                       ;83992A;
@@ -3113,9 +3117,11 @@ FXHeader_CeresRidley_State0:
     dw $0000,$FFFF,$FFFF,$0000                                           ;83A15E;
     db $00,$28,$02,$02,$00,$00,$00,$00                                   ;83A166;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FXHeader_83A16E:
     dw $0000,$FFFF,$FFFF,$0000                                           ;83A16E;
     db $00,$2A,$02,$02,$00,$00,$00,$00                                   ;83A176;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 FXHeader_FallingTile_State1:
     dw $FFFF                                                             ;83A17E;
@@ -3862,6 +3868,7 @@ Door_Colosseum_2:
     db $00,$04,$01,$06,$00,$00                                           ;83A7FA;
     dw $8000,$0000                                                       ;83A800;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Door_83A804:
     dw RoomHeader_HalfieClimb                                            ;83A804;
     db $00,$01,$00,$00,$00,$02                                           ;83A806;
@@ -3871,6 +3878,7 @@ UNUSED_Door_83A810:
     dw RoomHeader_MaridiaMissileRefill                                   ;83A810;
     db $00,$04,$01,$06,$00,$00                                           ;83A812;
     dw $8000,$0000                                                       ;83A818;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Door_ThePrecious_MaridiaLoad11:
     dw RoomHeader_ThePrecious                                            ;83A81C;

--- a/src/bank_84.asm
+++ b/src/bank_84.asm
@@ -85,6 +85,7 @@ Clear_Sounds_When_Going_Through_Door:
     RTL                                                                  ;848257;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Clear_SpinJumpSound_GoingThroughDoor_848258:
     LDA.W $0A1E                                                          ;848258;
     AND.W #$FF00                                                         ;84825B;
@@ -99,6 +100,7 @@ UNUSED_Clear_SpinJumpSound_GoingThroughDoor_848258:
 
 .return:
     RTL                                                                  ;84826F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Play_SpinJumpSound_if_SpinJumping:
@@ -107,6 +109,7 @@ Play_SpinJumpSound_if_SpinJumping:
     RTL                                                                  ;848277;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Play_Resumed_SpinJumpSound_848278:
     LDA.W $0A1E                                                          ;848278;
     AND.W #$FF00                                                         ;84827B;
@@ -121,6 +124,7 @@ UNUSED_Play_Resumed_SpinJumpSound_848278:
 
 .return:
     RTL                                                                  ;84828F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Calculate_PLM_Block_Coordinates:
@@ -535,6 +539,7 @@ RTS_84853D:
     RTS                                                                  ;84853D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spawn_Enemy_PLM_84853E:
     PHB                                                                  ;84853E;
     PHY                                                                  ;84853F;
@@ -601,6 +606,7 @@ UNUSED_Spawn_Enemy_PLM_84853E:
     PLY                                                                  ;8485B0;
     PLB                                                                  ;8485B1;
     RTL                                                                  ;8485B2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_8485B3:
@@ -807,6 +813,7 @@ RTS_8486D0:
     RTS                                                                  ;8486D0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_CallFuctionInY_8486D1:
     LDA.W $0000,Y                                                        ;8486D1;
     STA.B $12                                                            ;8486D4;
@@ -843,6 +850,7 @@ UNUSED_Instruction_PLM_CallFuctionInY_withA_8486E8:
 
 .externalFunction:
     JML.W [$0012]                                                        ;848708;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_CallFunctionInY:
@@ -871,6 +879,7 @@ Instruction_PLM_GotoY:
     RTS                                                                  ;848728;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_GotoY_PlusMinusY_848729:
     STY.B $12                                                            ;848729;
     DEY                                                                  ;84872B;
@@ -888,6 +897,7 @@ UNUSED_Instruction_PLM_GotoY_PlusMinusY_848729:
     ADC.B $12                                                            ;84873B;
     TAY                                                                  ;84873D;
     RTS                                                                  ;84873E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_DecrementTimer_GotoYIfNonZero:
@@ -898,11 +908,13 @@ Instruction_PLM_DecrementTimer_GotoYIfNonZero:
     RTS                                                                  ;848746;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_DecrementTimer_GotoYIfNonZero_848747:
     DEC.W $1D77,X                                                        ;848747;
     BNE UNUSED_Instruction_PLM_GotoY_PlusMinusY_848729                   ;84874A;
     INY                                                                  ;84874C;
     RTS                                                                  ;84874D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_TimerEqualsY_8Bit:
@@ -914,12 +926,14 @@ Instruction_PLM_TimerEqualsY_8Bit:
     RTS                                                                  ;848759;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_TimerEqualsY_16Bit_84875A:
     LDA.W $0000,Y                                                        ;84875A;
     STA.W $1D77,X                                                        ;84875D;
     INY                                                                  ;848760;
     INY                                                                  ;848761;
     RTS                                                                  ;848762;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_848763:
@@ -1025,12 +1039,14 @@ Instruction_PLM_GotoY_ifBossBitsSet:
     RTS                                                                  ;848820;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_SetBossBits_848821:
     LDA.W $0000,Y                                                        ;848821;
     AND.W #$00FF                                                         ;848824;
     JSL.L SetBossBitsInAForCurrentArea                                   ;848827;
     INY                                                                  ;84882B;
     RTS                                                                  ;84882C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_GotoY_ifEventIsSet:
@@ -1328,6 +1344,7 @@ Instruction_PLM_Return:
     RTS                                                                  ;848A3F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_WaitUntil_Enemy0_IsDead_848A40:
     LDA.W $0F86                                                          ;848A40;
     AND.W #$0200                                                         ;848A43;
@@ -1356,6 +1373,7 @@ UNUSED_Instruction_PLM_WaitUntil_Enemy0_IsDead_848A59:
 
 .return:
     RTS                                                                  ;848A71;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_GotoY_ifRoomArg_DoorIsSet:
@@ -1575,12 +1593,14 @@ Instruction_PLM_ProcessSolidScrollUpdate:
     RTS                                                                  ;848BD0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_QueueMusicTrack_Y_848BD1:
     LDA.W $0000,Y                                                        ;848BD1;
     AND.W #$00FF                                                         ;848BD4;
     JSL.L QueueMusicDataOrTrack_8FrameDelay                              ;848BD7;
     INY                                                                  ;848BDB;
     RTS                                                                  ;848BDC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_ClearMusicQueue_QueueMusicTrack:
@@ -1627,6 +1647,7 @@ Instruction_PLM_QueueSound_Y_Lib3_Max6:
     RTS                                                                  ;848C21;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_QueueSound_Y_Lib1_Max15_848C22:
     LDA.W $0000,Y                                                        ;848C22;
     JSL.L QueueSound                                                     ;848C25;
@@ -1653,6 +1674,7 @@ UNUSED_Instruction_PLM_QueueSound_Y_Lib1_Max3_848C3D:
     JSL.L QueueSound_Lib1_Max3                                           ;848C40;
     INY                                                                  ;848C44;
     RTS                                                                  ;848C45;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_QueueSound_Y_Lib2_Max3:
@@ -1662,6 +1684,7 @@ Instruction_PLM_QueueSound_Y_Lib2_Max3:
     RTS                                                                  ;848C4E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_QueueSound_Y_Lib3_Max3_848C4F:
     LDA.W $0000,Y                                                        ;848C4F;
     JSL.L QueueSound_Lib3_Max3                                           ;848C52;
@@ -1695,6 +1718,7 @@ UNUSED_Instruction_PLM_QueueSound_Y_Lib1_Max1_848C73:
     JSL.L QueueSound_Lib1_Max1                                           ;848C76;
     INY                                                                  ;848C7A;
     RTS                                                                  ;848C7B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_QueueSound_Y_Lib2_Max1:
@@ -1704,11 +1728,13 @@ Instruction_PLM_QueueSound_Y_Lib2_Max1:
     RTS                                                                  ;848C84;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_QueueSound_Y_Lib3_Max1_848C85:
     LDA.W $0000,Y                                                        ;848C85;
     JSL.L QueueSound_Lib3_Max1                                           ;848C88;
     INY                                                                  ;848C8C;
     RTS                                                                  ;848C8D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_848C8E:
@@ -1806,10 +1832,12 @@ Instruction_PLM_GotoY_or_ActivateSaveStation:
     RTS                                                                  ;848D38;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_ResumeMusicIn6Seconds_848D39:
     LDA.W #$0168                                                         ;848D39;
     JSL.L Play_Room_Music_Track_After_A_Frames                           ;848D3C;
     RTS                                                                  ;848D40;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PLM_GotoY_ifSamusIsWithin_YColumnsRowsOfPLM:
@@ -1862,6 +1890,7 @@ Instruction_PLM_GotoY_ifSamusIsWithin_YColumnsRowsOfPLM:
     RTS                                                                  ;848D88;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PLM_MovePLMDown1Block_848D89:
     LDA.W $1C87,X                                                        ;848D89;
     CLC                                                                  ;848D8C;
@@ -1869,25 +1898,30 @@ UNUSED_Instruction_PLM_MovePLMDown1Block_848D89:
     ADC.W $07A5                                                          ;848D90;
     STA.W $1C87,X                                                        ;848D93;
     RTS                                                                  ;848D96;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_848D97:
     RTS                                                                  ;848D97;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_DefaultPLM_848D98:
     dw $1000,InstList_PLM_DefaultPLMDrawInstruction                      ;848D98;
     dw Instruction_PLM_GotoY                                             ;848D9C;
     dw UNUSED_InstList_PLM_DefaultPLM_848D98                             ;848D9E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_DefaultPLMDrawInstruction:
 ; Note that this is an invalid draw instruction
 ; Used by instruction list $8D98: Unused. Default PLM instruction list
     dw $0180,$0000,$0000                                                 ;848DA0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawPLM_Custom_DrawInstPointer_TilemapBaseAddr_848DA6:
     JSR.W DrawPLM                                                        ;848DA6;
     RTL                                                                  ;848DA9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DrawPLM_HardCoded:
@@ -2579,9 +2613,11 @@ PartiallySetupVRAMWriteTableEntries_SingleScrnPLMDrawTilemap:
     RTS                                                                  ;84924C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 DrawInst_UnusedBlueBrinstarFaceBlock:
     dw $0001,$817E                                                       ;84924D;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_CrateriaMainStreetEscape:
     dw $0002,$00FF,$00FF                                                 ;849253;
@@ -2644,6 +2680,7 @@ DrawInst_ClearBotwoonWall:
     dw $00FF,$00FF
     dw $0000                                                 ;84931F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849325:
     dw $8009,$8053,$8053,$8053,$8053,$8053,$8053,$8053                   ;849325;
     dw $8053,$8053
@@ -2658,6 +2695,7 @@ UNUSED_DrawInst_849351:
     dw $8009,$0055,$0055,$0055,$0055,$0055,$0055,$0055                   ;849351;
     dw $0055,$0055
     dw $0000                                                 ;849361;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_CrumbleKraidCeiling_CrumbleKraidSpikes_Elevatube:
     dw $0001,$8180
@@ -2683,9 +2721,11 @@ DrawInst_SetKraidCeilingBlockToBackground3:
     dw $0001,$0130
     dw $0000                                                 ;849385;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_84938B:
     dw $0001,$011C
     dw $0000                                                 ;84938B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_CrumbleKraidSpikeBlocks_0:
     dw $0001,$0111
@@ -2740,6 +2780,7 @@ DrawInst_CrumbleSporeSpawnCeiling_2:
     dw $0002,$0055,$0055                                                 ;84944B;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849453:
     dw $8002,$00FF,$12FB                                                 ;849453;
     db $00,$FE                                                           ;849459;
@@ -2751,6 +2792,7 @@ UNUSED_DrawInst_849463:
     db $00,$FE                                                           ;849469;
     dw $8002,$8AFB,$80FF                                                 ;84946B;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_EscapeRoom1Gate_0:
     dw $8004,$80FF,$80FF,$80FF,$80FF                                     ;849473;
@@ -2764,6 +2806,7 @@ DrawInst_EscapeRoom1Gate_2:
     dw $8004,$830F,$8AE8,$82E8,$830F                                     ;84948B;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849497:
     dw $0001,$00FF                                                       ;849497;
     dw $0000
@@ -2771,6 +2814,7 @@ UNUSED_DrawInst_849497:
 UNUSED_DrawInst_84949D:
     dw $0001,$80FF                                                       ;84949D;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_FillMotherBrainsWall:
     dw $8002,$8340,$830F                                                 ;8494A3;
@@ -2784,6 +2828,7 @@ DrawInst_MotherBrainsRoomEscapeDoor:
     dw $8004,$0223,$01EB,$01D0,$0221                                     ;8494BD;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_8494C9:
     dw $000D,$8044,$8044,$8044,$8044,$8044,$8044,$8044                   ;8494C9;
     dw $8044,$8044,$8044,$8044,$8044,$8044                               ;8494D9;
@@ -2793,6 +2838,7 @@ UNUSED_DrawInst_8494E7:
     dw $000D,$8044,$8044,$8044,$8044,$8044,$8044,$8044                   ;8494E7;
     dw $8044,$8044,$8044,$8044,$8044,$8044                               ;8494F7;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_MotherBrainsBackgroundRow2:
     dw $000D,$1241,$1242,$12FC,$12FC,$12FC,$1243,$1244                   ;849505;
@@ -2854,6 +2900,7 @@ DrawInst_MotherBrainsBackgroundRowD:
     dw $1339,$124E,$1339,$1339,$124F,$1249                               ;84965F;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_94966D:
     dw $000D,$8319,$8319,$8319,$8319,$8319,$8319,$8319                   ;84966D;
     dw $8319,$8319,$8319,$8319,$8319,$8319                               ;84967D;
@@ -2863,6 +2910,7 @@ UNUSED_DrawInst_94968B:
     dw $000D,$8044,$8044,$8044,$8044,$8044,$8044,$8044                   ;84968B;
     dw $8044,$8044,$8044,$8044,$8044,$8044                               ;84969B;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_ClearCeilingBlockInMotherBrainsRoom:
     dw $8002,$12FC,$00FF                                                 ;8496A9;
@@ -2972,11 +3020,13 @@ UNUSED_DrawInst_849817:
     dw $00FF,$00FF,$8004,$00FF,$00FF,$00FF,$00FF                         ;849837;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849847:
     dw $8004,$00FF,$00FF,$00FF,$00FF,$00FF,$8004,$0172                   ;849847;
     dw $0173,$0173,$0172,$00FE,$8004,$0172,$0173,$0173                   ;849857;
     dw $0172,$00FD,$8004,$00FF,$00FF,$00FF,$00FF                         ;849867;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_BombTorizosCrumblingChozo_0:
     dw $0002,$8065,$8066                                                 ;849877;
@@ -2988,8 +3038,10 @@ DrawInst_BombTorizosCrumblingChozo_0:
     dw $0003,$8047,$8048,$8049                                           ;84988D;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849897:
     dw $0001,$0001,$0000                                                 ;849897;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_BombTorizosCrumblingChozo_1:
     dw $0002,$00FF,$00FF,$00FE,$0002,$00FF,$00FF,$01FE                   ;84989D;
@@ -3100,6 +3152,7 @@ DrawInst_SaveStation_2:
     dw $0002,$805A,$845A                                                 ;849AC7;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_Draw13BlankAirTiles_849ACF:
     dw $000D,$00FF,$00FF,$00FF,$00FF,$00FF,$00FF,$00FF                   ;849ACF;
     dw $00FF,$00FF,$00FF,$00FF,$00FF,$00FF                               ;849ADF;
@@ -3139,6 +3192,7 @@ UNUSED_DrawInst_LowerNorfair2x2ChozoShotBlock_849B4B:
     db $00,$01                                                           ;849B51;
     dw $0002,$00FF,$00FF                                                 ;849B53;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_ClearCrocomiresBridge:
     dw $000A,$0080,$0080,$0080,$0080,$0080,$0080,$0080                   ;849B5B;
@@ -3271,6 +3325,7 @@ DrawInst_EyeDoorBottomFacingRight_2:
     dw $0001,$A8AC                                                       ;849CA1;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_AlternateLowerNorfairChozoHand_849CA7:
     dw $0001,$C0FF                                                       ;849CA7;
     dw $0000
@@ -3290,6 +3345,7 @@ UNUSED_DrawInst_849CB9:
 UNUSED_DrawInst_AlternateLowerNorfairChozoHand_849CBF:
     dw $0001,$00FF                                                       ;849CBF;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_ClearSlopeAccessForWreckedShipChozo:
     dw $000E,$012B,$012B,$012B,$012B,$012B,$012B,$012B                   ;849CC5;
@@ -3319,6 +3375,7 @@ DrawInst_BlockSlopeAccessForWreckedShipChozo:
     dw $0001,$81BB                                                       ;849D53;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_WreckedShip3x4ChozoBombBlock_0_849D59:
     dw $8004,$C171,$D171,$D171,$D171                                     ;849D59;
     db $FF,$00                                                           ;849D63;
@@ -3358,6 +3415,7 @@ UNUSED_DrawInst_WreckedShip3x4ChozoBombBlock_4_849DE9:
     db $FE,$00                                                           ;849DFF;
     dw $8004,$D0FF,$D0FF,$D0FF,$30FF                                     ;849E01;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_BrinstarFloorPlant_0:
     dw $0002,$35A1,$85A0                                                 ;849E0D;
@@ -3367,6 +3425,7 @@ DrawInst_BrinstarFloorPlant_0:
     dw $0004,$2180,$2181,$2581,$2580                                     ;849E1D;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849E29:
     dw $0002,$05A1,$85A0                                                 ;849E29;
     db $FE,$00                                                           ;849E2F;
@@ -3374,6 +3433,7 @@ UNUSED_DrawInst_849E29:
     db $FE,$FF                                                           ;849E37;
     dw $0004,$2180,$2181,$2581,$2580                                     ;849E39;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_BrinstarFloorPlant_1:
     dw $0002,$05A3,$85A2                                                 ;849E45;
@@ -3407,6 +3467,7 @@ DrawInst_BrinstarCeilingPlant_0:
     dw $0004,$2980,$2981,$2D81,$2D80                                     ;849EA9;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_849EB5:
     dw $0002,$0DA1,$8DA0                                                 ;849EB5;
     db $FE,$00                                                           ;849EBB;
@@ -3414,6 +3475,7 @@ UNUSED_DrawInst_849EB5:
     db $FE,$01                                                           ;849EC3;
     dw $0004,$2980,$2981,$2D81,$2D80                                     ;849EC5;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_BrinstarCeilingPlant_1:
     dw $0002,$0DA3,$8DA2                                                 ;849ED1;
@@ -3553,6 +3615,7 @@ UNUSED_DrawInst_DraygonCannonShieldDownRight_1_849FFD:
     dw $0002,$D532,$D531                                                 ;84A005;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_DraygonCannonShieldUpRight_0_84A00D:
     dw $0002,$CD30,$5D2F                                                 ;84A00D;
     db $00,$01                                                           ;84A013;
@@ -3564,6 +3627,7 @@ UNUSED_DrawInst_DraygonCannonShieldUpRight_1_84A01D:
     db $00,$01                                                           ;84A023;
     dw $0002,$DD12,$DD11                                                 ;84A025;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_DraygonCannonRight_0:
     dw $0002,$A580,$00FF                                                 ;84A02D;
@@ -3589,6 +3653,7 @@ DrawInst_DraygonCannonRight_3:
     dw $0002,$A5A3,$00FF                                                 ;84A065;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_DraygonCannonDownRight_0_84A06D:
     dw $0002,$A5A5,$A5A4                                                 ;84A06D;
     db $00,$01                                                           ;84A073;
@@ -3636,6 +3701,7 @@ UNUSED_DrawInst_DraygonCannonUpRight_3_84A0DD:
     db $00,$01                                                           ;84A0E3;
     dw $0002,$ADAB,$ADAA                                                 ;84A0E5;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_DraygonCannonShieldLeft_0:
     dw $0001,$C114                                                       ;84A0ED;
@@ -3653,6 +3719,7 @@ DrawInst_DraygonCannonShieldLeft_1:
     dw $0002,$0135,$D136                                                 ;84A10D;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_DraygonCannonShieldDownLeft_0_84A115:
     dw $0001,$C110                                                       ;84A115;
     db $FF,$00                                                           ;84A119;
@@ -3684,6 +3751,7 @@ UNUSED_DrawInst_DraygonCannonShieldUpLeft_1_84A151:
     db $FF,$01                                                           ;84A15B;
     dw $0002,$D911,$D912                                                 ;84A15D;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_DraygonCannonLeft_0:
     dw $0001,$A180                                                       ;84A165;
@@ -3717,6 +3785,7 @@ DrawInst_DraygonCannonLeft_3:
     dw $0002,$00FF,$A1A3                                                 ;84A1AD;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_DraygonCannonDownLeft_0_84A1B5:
     dw $0001,$A1A5                                                       ;84A1B5;
     db $FF,$00                                                           ;84A1B9;
@@ -3820,11 +3889,13 @@ UNUSED_DrawInst_84A2A5:
     db $FF,$00                                                           ;84A2AB;
     dw $8002,$2333,$2353                                                 ;84A2AD;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_ItemChozoOrb:
     dw $0001,$00FF                                                       ;84A2B5;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_84A2BB:
     dw $0001,$805D                                                       ;84A2BB;
     dw $0000
@@ -3832,6 +3903,7 @@ UNUSED_DrawInst_84A2BB:
 UNUSED_DrawInst_84A2C1:
     dw $0001,$805E                                                       ;84A2C1;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_ItemOrb_0:
     dw $0001,$C072                                                       ;84A2C7;
@@ -4001,6 +4073,7 @@ DrawInst_ItemShotBlock_2:
     dw $0001,$8055                                                       ;84A3E9;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_84A3EF:
     dw $0001,$80FF                                                       ;84A3EF;
     dw $0000
@@ -4064,6 +4137,7 @@ UNUSED_DrawInst_84A465:
 UNUSED_DrawInst_1x1ShotBlock_84A475:
     dw $0001,$C052                                                       ;84A475;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_2x1RespawningShotBlock:
     dw $0002,$C096,$5097                                                 ;84A47B;
@@ -4097,9 +4171,11 @@ DrawInst_2x2RespawningCrumbleBlock:
     dw $0002,$D0BC,$D0BC                                                 ;84A4B9;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_84A4C1:
     dw $0001,$F058                                                       ;84A4C1;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_2x1RespawningBombBlock:
     dw $0002,$F058,$5058                                                 ;84A4C7;
@@ -4597,9 +4673,11 @@ DrawInst_BlueDoorFacingRight_2:
     dw $8004,$840F,$042F,$0C2F,$8C0F                                     ;84AA13;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_84AA1F:
     dw $0004,$841D,$541C,$501C,$501D                                     ;84AA1F;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_DoorFacingUp_AA2B:
     dw $0004,$C41D,$541C,$501C,$501D                                     ;84AA2B;
@@ -4617,9 +4695,11 @@ DrawInst_BlueDoorFacingUp_2:
     dw $0004,$843F,$843E,$803E,$803F                                     ;84AA4F;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_84AA5B:
     dw $0004,$8C1D,$5C1C,$581C,$581D                                     ;84AA5B;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_DoorFacingDown_AA67:
     dw $0004,$CC1D,$5C1C,$581C,$581D                                     ;84AA67;
@@ -4662,8 +4742,10 @@ DrawInst_ElevatorPlatform_2:
     dw $0000
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_DrawEmptyTile_84AADF:
     dw $0001,DrawInst_ItemChozoOrb                                       ;84AADF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_Delete:
     dw Instruction_PLM_Delete                                            ;84AAE3;
@@ -4809,6 +4891,7 @@ InstList_PLM_ClearKraidSpikeBlocks:
     dw $0001,DrawInst_ClearKraidSpikeBlocks                              ;84ABDD;
     dw Instruction_PLM_Delete                                            ;84ABE1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_84ABE3:
     dw $0001,UNUSED_DrawInst_849453                                      ;84ABE3;
     dw Instruction_PLM_Delete                                            ;84ABE7;
@@ -4831,6 +4914,7 @@ UNUSED_InstList_PLM_84ABF9:
 UNUSED_PLM_InstList_84ABFF:
     dw $0001,UNUSED_DrawInst_84949D                                      ;84ABFF;
     dw Instruction_PLM_Delete                                            ;84AC03;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_FillMotherBrainsWall:
     dw $0001,DrawInst_FillMotherBrainsWall                               ;84AC05;
@@ -4888,6 +4972,7 @@ InstList_PLM_MotherBrainsBackgroundRowD:
     dw $0001,DrawInst_MotherBrainsBackgroundRowD                         ;84AC53;
     dw Instruction_PLM_Delete                                            ;84AC57;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_84AC59:
     dw $0001,UNUSED_DrawInst_94966D                                      ;84AC59;
     dw Instruction_PLM_Delete                                            ;84AC5D;
@@ -4895,6 +4980,7 @@ UNUSED_InstList_PLM_84AC59:
 UNUSED_InstList_PLM_84AC5F:
     dw $0001,UNUSED_DrawInst_94968B                                      ;84AC5F;
     dw Instruction_PLM_Delete                                            ;84AC63;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_ClearCeilingBlockInMotherBrainsRoom:
     dw $0001,DrawInst_ClearCeilingBlockInMotherBrainsRoom                ;84AC65;
@@ -5215,6 +5301,7 @@ Instruction_PLM_GotoY_EnableMovementIfSamusMissilesAreFull:
     RTS                                                                  ;84AED5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 InstList_PLM_Nothing_84AED6:
     dw Instruction_PLM_Delete                                            ;84AED6;
 
@@ -5260,14 +5347,17 @@ InstList_PLM_Nothing_84AF1E:
     dw $0012,UNUSED_DrawInst_84A2A5                                      ;84AF5A;
     dw Instruction_PLM_GotoY                                             ;84AF5E;
     dw InstList_PLM_Nothing_84AF1E                                       ;84AF60;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_Debug_ScrollPLM:
     dw $0001,$3074                                                       ;84AF62;
     dw $0000
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawInst_Debug_SolidScrollPLM_84AF68:
     dw $0001,$B074                                                       ;84AF68;
     dw $0000
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DrawInst_Debug_LeftwardsExtension:
     dw $0001,$5011                                                       ;84AF6E;
@@ -5294,8 +5384,10 @@ InstList_PLM_ScrollPLM_1:
     dw Instruction_PLM_GotoY                                             ;84AF8E;
     dw InstList_PLM_ScrollPLM_1                                          ;84AF90;
 
+if !FEATURE_KEEP_UNREFERENCED
 InstList_PLM_SolidScrollPLM_0:
     dw $0001,UNUSED_DrawInst_Debug_SolidScrollPLM_84AF68                 ;84AF92;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_SolidScrollPLM_1:
     dw Instruction_PLM_Sleep                                             ;84AF96;
@@ -5400,6 +5492,7 @@ Instruction_PLM_EnableMovement_SetSaveStationUsed:
     RTS                                                                  ;84B03D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_Draw13BlankAirTiles_84B03E:
     dw $0001,UNUSED_DrawInst_Draw13BlankAirTiles_849ACF                  ;84B03E;
     dw Instruction_PLM_Delete                                            ;84B042;
@@ -5407,6 +5500,7 @@ UNUSED_InstList_PLM_Draw13BlankAirTiles_84B03E:
 UNUSED_InstList_PLM_Draw13BlankSolidTiles_84B044:
     dw $0001,UNUSED_DrawInst_Draw13BlankSolidTiles_849AED                ;84B044;
     dw Instruction_PLM_Delete                                            ;84B048;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Setup_WreckedShipEntranceTreadmill:
     LDX.W $1C87,Y                                                        ;84B04A;
@@ -5422,6 +5516,7 @@ Setup_WreckedShipEntranceTreadmill:
     RTS                                                                  ;84B05C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LoadFXEntry_CompletelyBroken_84B05D:
     PHB                                                                  ;84B05D;
     PHA                                                                  ;84B05E;
@@ -5511,6 +5606,7 @@ UNUSED_LoadFXEntry2IfPLMIsInLeftmostScreenColumn_84B0C1:
 .return:
     CLC                                                                  ;84B0DA;
     RTS                                                                  ;84B0DB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_BrinstarFloorPlant:
@@ -5954,10 +6050,12 @@ Setup_EnemyBreakableBlock:
     RTS                                                                  ;84B3E2;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Setup_TorizoDrool_84B3E3:
     LDY.W #UNUSED_EnemyProjectile_BombTorizo_86A977                      ;84B3E3;
     JSL.L SpawnEnemyProjectileY_ParameterA_RoomGraphics                  ;84B3E6;
     RTS                                                                  ;84B3EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_IcePhysics:
@@ -6326,9 +6424,11 @@ PLMEntries_collisionReactionClearCarry:
     dw Setup_ClearCarry                                                  ;84B633;
     dw InstList_PLM_Delete                                               ;84B635;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84B637:
     dw Setup_SetCarry                                                    ;84B637;
     dw InstList_PLM_Delete                                               ;84B639;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_rightwardsExtension:
     dw Setup_RightwardsExtension                                         ;84B63B;
@@ -6366,6 +6466,7 @@ PLMEntries_insideReactionNothing_B65B:
     dw RTS_84B3CF                                                        ;84B65B;
     dw InstList_PLM_Delete                                               ;84B65D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84B65F:
     dw Setup_DeactivatePLM                                               ;84B65F;
     dw UNUSED_InstList_PLM_84ABE3                                        ;84B661;
@@ -6385,6 +6486,7 @@ UNUSED_PLMEntries_84B66B:
 UNUSED_PLMEntries_84B66F:
     dw Setup_DeactivatePLM                                               ;84B66F;
     dw UNUSED_PLM_InstList_84ABFF                                        ;84B671;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_fillMotherBrainsWall:
     dw Setup_DeactivatePLM                                               ;84B673;
@@ -6442,6 +6544,7 @@ PLMEntries_motherBrainsBackgroundRowD:
     dw Setup_DeactivatePLM                                               ;84B6A7;
     dw InstList_PLM_MotherBrainsBackgroundRowD                           ;84B6A9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84B6AB:
     dw Setup_DeactivatePLM                                               ;84B6AB;
     dw UNUSED_InstList_PLM_84AC59                                        ;84B6AD;
@@ -6449,6 +6552,7 @@ UNUSED_PLMEntries_84B6AB:
 UNUSED_PLMEntries_84B6AF:
     dw Setup_DeactivatePLM                                               ;84B6AF;
     dw UNUSED_InstList_PLM_84AC5F                                        ;84B6B1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_clearCeilingBlockInMotherBrainsRoom:
     dw Setup_DeactivatePLM                                               ;84B6B3;
@@ -6518,6 +6622,7 @@ PLMEntries_missileStationLeftAccess:
     dw Setup_MissileStationLeftAccess                                    ;84B6F3;
     dw InstList_PLM_MissileStationLeftAccess_0                           ;84B6F5;
 
+if !FEATURE_KEEP_UNREFERENCED
 PLMEntries_nothing_84B6F7:
     dw Setup_DeactivatePLM                                               ;84B6F7;
     dw InstList_PLM_Nothing_84AED6                                       ;84B6F9;
@@ -6525,6 +6630,7 @@ PLMEntries_nothing_84B6F7:
 PLMEntries_nothing_84B6FB:
     dw Setup_DeactivatePLM                                               ;84B6FB;
     dw InstList_PLM_Nothing_84AF1C                                       ;84B6FD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_scrollPLMTrigger:
     dw Setup_ScrollBlockTouchPLM                                         ;84B6FF;
@@ -6534,9 +6640,11 @@ PLMEntries_ScrollPLM:
     dw Setup_ScrollPLM                                                   ;84B703;
     dw InstList_PLM_ScrollPLM_0                                          ;84B705;
 
+if !FEATURE_KEEP_UNREFERENCED
 PLMEntries_unusedSolidScrollPLM:
     dw Setup_SolidScrollPLM                                              ;84B707;
     dw InstList_PLM_SolidScrollPLM_0                                     ;84B709;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_elevatorPlatform:
     dw Setup_DeactivatePLM                                               ;84B70B;
@@ -6550,6 +6658,7 @@ PLMEntries_insideReactionQuicksandSurface:
     dw Setup_QuicksandSurface                                            ;84B713;
     dw InstList_PLM_Delete                                               ;84B715;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84B717:
     dw Setup_QuicksandSurface                                            ;84B717;
     dw InstList_PLM_Delete                                               ;84B719;
@@ -6557,6 +6666,7 @@ UNUSED_PLMEntries_84B717:
 UNUSED_PLMEntries_84B71B:
     dw Setup_QuicksandSurface                                            ;84B71B;
     dw InstList_PLM_Delete                                               ;84B71D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_insideReactionSubmergingQuicksand:
     dw Setup_Inside_SubmergingQuicksand                                  ;84B71F;
@@ -6574,6 +6684,7 @@ PLMEntries_collisionReactionQuicksandSurface:
     dw Setup_QuicksandSurface_BTS85                                      ;84B72B;
     dw InstList_PLM_Delete                                               ;84B72D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84B72F:
     dw Setup_QuicksandSurface_BTS85                                      ;84B72F;
     dw InstList_PLM_Delete                                               ;84B731;
@@ -6581,6 +6692,7 @@ UNUSED_PLMEntries_84B72F:
 UNUSED_PLMEntries_84B733:
     dw Setup_QuicksandSurface_BTS85                                      ;84B733;
     dw InstList_PLM_Delete                                               ;84B735;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_collisionReactionSubmergingQuicksand:
     dw Setup_Collision_SubmergingQuicksand                               ;84B737;
@@ -6594,9 +6706,11 @@ PLMEntries_collisionReactionSandFallsFast:
     dw Setup_CollisionReaction_SandFalls                                 ;84B73F;
     dw InstList_PLM_Delete                                               ;84B741;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_unusedTorizoDrool_84B743:
     dw UNUSED_Setup_TorizoDrool_84B3E3                                   ;84B743;
     dw InstList_PLM_Delete                                               ;84B745;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_clearCrocomiresBridge:
     dw Setup_DeactivatePLM                                               ;84B747;
@@ -6618,6 +6732,7 @@ PLMEntries_createCrocomireInvisibleWall:
     dw Setup_DeactivatePLM                                               ;84B757;
     dw InstList_PLM_CreateCrocomiresInvisibleWall                        ;84B759;
 
+if !FEATURE_KEEP_UNREFERENCED
 PLMEntries_unusedDraw13BlankAirTiles:
     dw RTS_84B3CF                                                        ;84B75B;
     dw UNUSED_InstList_PLM_Draw13BlankAirTiles_84B03E                    ;84B75D;
@@ -6625,6 +6740,7 @@ PLMEntries_unusedDraw13BlankAirTiles:
 PLMEntries_unusedDraw13BlankSolidTiles:
     dw RTS_84B3CF                                                        ;84B75F;
     dw UNUSED_InstList_PLM_Draw13BlankSolidTiles_84B044                  ;84B761;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_clearBabyMetroidInvisibleWall:
     dw Setup_ClearBabyMetroidInvisibleWall                               ;84B763;
@@ -6682,9 +6798,11 @@ PLMEntries_crumbleBotwoonWall:
     dw Setup_CrumbleBotwoonWall_Wait40Frames                             ;84B79B;
     dw InstList_PLM_CrumbleBotwoonWall_0                                 ;84B79D;
 
+if !FEATURE_KEEP_UNREFERENCED
 PLMEntries_unusedSetKraidCeilingBlockToBackground1:
     dw Setup_DeactivatePLM                                               ;84B79F;
     dw InstList_PLM_SetKraidCeilingBlockToBackground1                    ;84B7A1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_crumbleKraidCeilingBlockIntoBackground1:
     dw Setup_DeactivatePLM                                               ;84B7A3;
@@ -7199,6 +7317,7 @@ InstList_PLM_BombTorizoGreyDoor_5:
     dw DrawInst_DoorFacingRight_A683                                     ;84BACD;
     dw Instruction_PLM_Delete                                            ;84BACF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Setup_84BAD1:
     LDA.W $1DC8,Y                                                        ;84BAD1;
     AND.W #$007C                                                         ;84BAD4;
@@ -7213,6 +7332,7 @@ UNUSED_Setup_84BAD1:
     LDA.W #$C044                                                         ;84BAED;
     JSR.W Write_Level_Data_Block_Type_and_BTS                            ;84BAF0;
     RTS                                                                  ;84BAF3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 PLMEntries_bombTorizoGreyDoor:
@@ -7271,12 +7391,14 @@ InstList_PLM_GateThatClosesDuringEscapeAfterMotherBrain_0:
     dw DrawInst_EscapeRoom1Gate_2                                        ;84BB36;
     dw Instruction_PLM_Delete                                            ;84BB38;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_84BB34:
     dw $0006                                                             ;84BB3A;
     dw DrawInst_EscapeRoom1Gate_1                                        ;84BB3C;
     dw $005E                                                             ;84BB3E;
     dw DrawInst_EscapeRoom1Gate_0                                        ;84BB40;
     dw Instruction_PLM_Delete                                            ;84BB42;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_GateThatClosesDuringEscapeAfterMotherBrain_1:
     dw $0002                                                             ;84BB44;
@@ -9498,6 +9620,7 @@ PLMEntries_gateThatClosesInEscapeRoom1_PLM:
     dw Setup_DeactivatePLM                                               ;84C8D0;
     dw InstList_PLM_GateThatClosesDuringEscapeAfterMotherBrain_1         ;84C8D2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_Draws1x1ShotBlock_84C8D4:
     dw $0001                                                             ;84C8D4;
     dw UNUSED_DrawInst_1x1ShotBlock_84A475                               ;84C8D6;
@@ -9517,6 +9640,7 @@ UNUSED_InstList_PLM_Draws2x2ShotBlock_84C8E6:
     dw $0001                                                             ;84C8E6;
     dw DrawInst_2x2RespawningShotBlock                                   ;84C8E8;
     dw Instruction_PLM_Delete                                            ;84C8EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_BombReaction_PLM_1x1RespawningCrumbleBlock:
     dw $0001                                                             ;84C8EC;
@@ -9538,6 +9662,7 @@ InstList_BombReaction_PLM_2x2RespawningCrumbleBlock:
     dw DrawInst_2x2RespawningCrumbleBlock                                ;84C900;
     dw Instruction_PLM_Delete                                            ;84C902;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_84C904:
     dw $0001                                                             ;84C904;
     dw UNUSED_DrawInst_84A4C1                                            ;84C906;
@@ -9557,6 +9682,7 @@ UNUSED_InstList_PLM_84C916:
     dw $0001                                                             ;84C916;
     dw DrawInst_2x2RespawningBombBlock                                   ;84C918;
     dw Instruction_PLM_Delete                                            ;84C91A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_InstList_PLM_PowerBombBlockBombed_84C91C:
     dw $0001                                                             ;84C91C;
@@ -9573,6 +9699,7 @@ InstList_PLM_BombReaction_SpeedBlock:
     dw DrawInst_BombReactionSpeedBlock                                   ;84C92A;
     dw Instruction_PLM_Delete                                            ;84C92C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_84C92E:
     dw Instruction_PLM_QueueSound_Y_Lib2_Max6                            ;84C92E;
     db $06                                                               ;84C930;
@@ -9592,6 +9719,7 @@ UNUSED_InstList_PLM_84C92E:
     dw DrawInst_Respawn1x1_0                                             ;84C94B;
     dw Instruction_PLM_DrawPLMBlock                                      ;84C94D;
     dw Instruction_PLM_Delete                                            ;84C94F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_RespawningSpeedBlock_SlowerCrumbleAnimation:
     dw Instruction_PLM_QueueSound_Y_Lib2_Max1                            ;84C951;
@@ -9653,6 +9781,7 @@ InstList_PLM_RespawningSpeedBlock:
     dw Instruction_PLM_DrawPLMBlock_Clone                                ;84C9B6;
     dw Instruction_PLM_Delete                                            ;84C9B8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_84C9BA:
     dw Instruction_PLM_QueueSound_Y_Lib2_Max6                            ;84C9BA;
     db $06                                                               ;84C9BC;
@@ -9665,6 +9794,7 @@ UNUSED_InstList_PLM_84C9BA:
     dw $0001                                                             ;84C9C9;
     dw DrawInst_Respawn1x1_3                                             ;84C9CB;
     dw Instruction_PLM_Delete                                            ;84C9CD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_SpeedBlockSlowerCrumbleAnimation:
     dw Instruction_PLM_QueueSound_Y_Lib2_Max1                            ;84C9CF;
@@ -10294,6 +10424,7 @@ InstList_PLM_BreakableGrappleBlock:
     dw DrawInst_BreakableGrappleBlock_4                                  ;84CDBE;
     dw Instruction_PLM_Delete                                            ;84CDC0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Setup_84CDC2:
     LDA.W $0A1C                                                          ;84CDC2;
     CMP.W #$0081                                                         ;84CDC5;
@@ -10316,6 +10447,7 @@ UNUSED_Setup_84CDC2:
     STA.W $1C37,Y                                                        ;84CDE5;
     SEC                                                                  ;84CDE8;
     RTS                                                                  ;84CDE9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_Collision_RespawningSpeedBoostBlock:
@@ -10579,6 +10711,7 @@ Setup_DraygonsBrokenTurret:
     RTS                                                                  ;84CFEB;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_Draws1x1ShotBlock_84CFEC:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84CFEC;
     dw UNUSED_InstList_PLM_Draws1x1ShotBlock_84C8D4                      ;84CFEE;
@@ -10594,6 +10727,7 @@ UNUSED_PLMEntries_Draws2x1ShotBlock_84CFF4:
 UNUSED_PLMEntries_Draws2x2ShotBlock_84CFF8:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84CFF8;
     dw UNUSED_InstList_PLM_Draws2x2ShotBlock_84C8E6                      ;84CFFA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_1x1RespawningCrumbleBlock:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84CFFC;
@@ -10611,6 +10745,7 @@ PLMEntries_2x2RespawningCrumbleBlock:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84D008;
     dw InstList_BombReaction_PLM_2x2RespawningCrumbleBlock               ;84D00A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84D00C:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84D00C;
     dw UNUSED_InstList_PLM_84C904                                        ;84D00E;
@@ -10634,11 +10769,13 @@ UNUSED_PLMEntries_84D01C:
 UNUSED_PLMEntries_84D020:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84D020;
     dw UNUSED_InstList_PLM_SuperMissileBlockBombed_84C922                ;84D022;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_BombReaction_SpeedBoostBlock:
     dw Setup_Reaction_SpeedCrumbleBlock                                  ;84D024;
     dw InstList_PLM_BombReaction_SpeedBlock                              ;84D026;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_84D028:
     dw UNUSED_Setup_84CDC2                                               ;84D028;
     dw UNUSED_InstList_PLM_84C92E                                        ;84D02A;
@@ -10646,6 +10783,7 @@ UNUSED_PLMEntries_84D028:
 UNUSED_PLMEntries_84D02C:
     dw UNUSED_Setup_84CDC2                                               ;84D02C;
     dw UNUSED_InstList_PLM_84C9BA                                        ;84D02E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_Collision_BTS82:
     dw Setup_Collision_RespawningSpeedBoostBlock                         ;84D030;
@@ -10835,6 +10973,7 @@ PLMEntries_Grappled_DraygonsBrokenTurret:
     dw Setup_DraygonsBrokenTurret                                        ;84D0E8;
     dw InstList_PLM_GrappleBlock                                         ;84D0EA;
 
+if !FEATURE_KEEP_UNREFERENCED
 InstList_PLM_UnusedBlueBrinstarFaceBlock:
     dw $0001                                                             ;84D0EC;
     dw DrawInst_UnusedBlueBrinstarFaceBlock                              ;84D0EE;
@@ -10843,6 +10982,7 @@ InstList_PLM_UnusedBlueBrinstarFaceBlock:
 PLMEntries_UnusedBlueBrinstarFaceBlock:
     dw Setup_DeactivatePLM                                               ;84D0F2;
     dw InstList_PLM_UnusedBlueBrinstarFaceBlock                          ;84D0F4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_CrumbleLowerNorfairChozoRoomPlug:
     dw $0004                                                             ;84D0F6;
@@ -10866,6 +11006,7 @@ PLMEntries_CrumbleLowerNorfairChozoRoomPlug:
     dw Setup_CrumbleLowerNorfairChozoRoomPlug                            ;84D113;
     dw InstList_PLM_CrumbleLowerNorfairChozoRoomPlug                     ;84D115;
 
+if !FEATURE_KEEP_UNREFERENCED
 Setup_UnusedShotBlock:
     LDX.W $1C87,Y                                                        ;84D117;
     LDA.W #$C000                                                         ;84D11A;
@@ -10897,6 +11038,7 @@ InstList_PLM_UnusedGrappleBlock:
 PLMEntries_UnusedGrappleBlock:
     dw Setup_UnusedGrappleBlock                                          ;84D13B;
     dw InstList_PLM_UnusedGrappleBlock                                   ;84D13D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_LowerNorfairChozoHand_0:
     dw Instruction_PLM_GotoY_ifEventIsSet                                ;84D13F;
@@ -11271,6 +11413,7 @@ Instruction_PLM_RevertWreckedShipChozosSlopesIntoSpikes:
     RTS                                                                  ;84D408;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PreInst_PLM_GotoToLinkInstructionIfBombed_84D409:
     LDA.W $1D77,X                                                        ;84D409;
     AND.W #$0F00                                                         ;84D40C;
@@ -11384,6 +11527,7 @@ InstList_PLM_UnusedLowerNorfair2x2ChozoShotBlock_84D4B8:
     dw $0001                                                             ;84D4B8;
     dw UNUSED_DrawInst_LowerNorfair2x2ChozoShotBlock_849B4B              ;84D4BA;
     dw Instruction_PLM_Delete                                            ;84D4BC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RTS_84D4BE:
     RTS                                                                  ;84D4BE;
@@ -11609,6 +11753,7 @@ Setup_Collision_WreckedShipChozoHandTrigger:
     RTS                                                                  ;84D67E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 Setup_UnusedWreckedShip3x4ChozoBombBlock:
     LDX.W $1C87,Y                                                        ;84D67F;
     LDA.W #$0044                                                         ;84D682;
@@ -11649,6 +11794,7 @@ Setup_UnusedLowerNorfair2x2ChozoShotBlock:
     LDA.W #$D0FF                                                         ;84D6C5;
     JSR.W Write_Level_Data_Block_Type_and_BTS                            ;84D6C8;
     RTS                                                                  ;84D6CB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_NoobTube:
@@ -11670,6 +11816,7 @@ PLMEntries_MotherBrainsGlass:
     dw Setup_MotherBrainsGlass                                           ;84D6DE;
     dw InstList_PLM_MotherBrainsGlass_0                                  ;84D6E0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_MotherBrainsGlass_AreaBossDead_84D6E2:
     dw Setup_DeactivatePLM                                               ;84D6E2;
     dw InstList_PLM_UnusedMotherBrainsGlass_AreaBossDead                 ;84D6E4;
@@ -11677,6 +11824,7 @@ UNUSED_PLMEntries_MotherBrainsGlass_AreaBossDead_84D6E2:
 UNUSED_PLMEntries_MotherBrainsGlass_NoGlassState_84D6E6:
     dw Setup_DeactivatePLM                                               ;84D6E6;
     dw InstList_PLM_UnusedMotherBrainsGlass_NoGlassState                 ;84D6E8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_BombTorizosCrumblingChozo:
     dw Setup_BombTorizosCrumblingChozo                                   ;84D6EA;
@@ -11706,6 +11854,7 @@ PLMEntries_BlockSlopeAccessForWreckedShipChozo:
     dw RTS_84D6F7                                                        ;84D6FC;
     dw InstList_PLM_BlockSlopeAccessForWreckedShipChozo                  ;84D6FE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_WreckedShip3x4ChozoShotBlock_84D700:
     dw Setup_UnusedWreckedShip3x4ChozoBombBlock                          ;84D700;
     dw UNUSED_InstList_PLM_WreckedShip3x4ChozoBombBlock_84D426           ;84D702;
@@ -11717,11 +11866,13 @@ UNUSED_PLMEntries_AltLowerNorfairChozoHand_84D704:
 UNUSED_PLMEntries_LowerNorfair2x2ChozoShotBlock_84D708:
     dw Setup_UnusedLowerNorfair2x2ChozoShotBlock                         ;84D708;
     dw InstList_PLM_UnusedLowerNorfair2x2ChozoShotBlock_84D490           ;84D70A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_NoobTube:
     dw Setup_NoobTube                                                    ;84D70C;
     dw InstList_PLM_NoobTube_0                                           ;84D70E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PreInst_PLM_WakePLMIfSamusIsWithin4Blocks_84D710:
     JSL.L Calculate_PLM_Block_Coordinates                                ;84D710;
     LDA.W $0AF6                                                          ;84D714;
@@ -11761,6 +11912,7 @@ UNUSED_PreInst_PLM_WakePLMIfSamusIsWithin4Blocks_84D710:
 
 .return:
     RTS                                                                  ;84D752;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 PreInstruction_PLM_WakePLMIfRoomArgDoorIsSet:
@@ -12708,6 +12860,7 @@ InstList_PLM_DraygonCannonWithShieldFacingDownRight_2:
 UNUSED_InstList_PLM_DraygonCannonFacingDownRight_0:
     dw Instruction_PLM_DamageDraygonTurretFacingDownRight                ;84DD5A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PLM_DraygonCannonFacingDownRight_1:
     dw $0006                                                             ;84DD5C;
     dw UNUSED_DrawInst_DraygonCannonDownRight_0_84A06D                   ;84DD5E;
@@ -12766,6 +12919,7 @@ UNUSED_InstList_PLM_DraygonCannonFacingUpRight_84DDA5:
     dw UNUSED_DrawInst_DraygonCannonUpRight_3_84A0DD                     ;84DDB3;
     dw Instruction_PLM_GotoY                                             ;84DDB5;
     dw UNUSED_InstList_PLM_DraygonCannonFacingUpRight_84DDA5             ;84DDB7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PLM_DraygonCannonWithShieldFacingLeft_0:
     dw Instruction_PLM_LinkInstruction_Y                                 ;84DDB9;
@@ -12814,6 +12968,7 @@ InstList_PLM_DraygonCannonFacingLeft_1:
     dw Instruction_PLM_GotoY                                             ;84DDFE;
     dw InstList_PLM_DraygonCannonFacingLeft_1                            ;84DE00;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DraygonCannonWithShieldFacingDownLeft_84DE02:
     dw Instruction_PLM_LinkInstruction_Y                                 ;84DE02;
     dw UNUSED_InstList_DraygonCannonWithShieldFacingDownLeft_84DE14      ;84DE04;
@@ -12907,6 +13062,7 @@ UNUSED_InstList_PLM_DraygonCannonFacingUpLeft_84DE80:
     dw UNUSED_DrawInst_DraygonCannonUpLeft_3_84A241                      ;84DE8E;
     dw Instruction_PLM_GotoY                                             ;84DE90;
     dw UNUSED_InstList_PLM_DraygonCannonFacingUpLeft_84DE80              ;84DE92;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Setup_DraygonCannonWithShieldFacingRight:
     LDA.W $1DC7,Y                                                        ;84DE94;
@@ -12926,6 +13082,7 @@ Setup_DraygonCannonWithShieldFacingRight:
     RTS                                                                  ;84DEB8;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Setup_DraygonCannonWithShieldFacingDownUpRight_84DEB9:
     LDA.W $1DC7,Y                                                        ;84DEB9;
     STA.W $1E17,Y                                                        ;84DEBC;
@@ -12950,6 +13107,7 @@ UNUSED_Setup_DraygonCannonWithShieldFacingDownUpRight_84DEB9:
     LDA.W #$D0FF                                                         ;84DEE9;
     JSR.W Write_Level_Data_Block_Type_and_BTS                            ;84DEEC;
     RTS                                                                  ;84DEEF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_DraygonCannonWithShieldFacingLeft:
@@ -12970,6 +13128,7 @@ Setup_DraygonCannonWithShieldFacingLeft:
     RTS                                                                  ;84DF14;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Setup_DraygonCannonWithShieldFacingDownUpLeft_84DF15:
     LDA.W $1DC7,Y                                                        ;84DF15;
     STA.W $1E17,Y                                                        ;84DF18;
@@ -12994,6 +13153,7 @@ UNUSED_Setup_DraygonCannonWithShieldFacingDownUpLeft_84DF15:
     LDA.W #$D0FF                                                         ;84DF45;
     JSR.W Write_Level_Data_Block_Type_and_BTS                            ;84DF48;
     RTS                                                                  ;84DF4B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_DraygonCannon:
@@ -13008,6 +13168,7 @@ PLMEntries_DraygonCannonWithShieldFacingRight:
     dw Setup_DraygonCannonWithShieldFacingRight                          ;84DF59;
     dw InstList_PLM_DraygonCannonWithShieldFacingRight_0                 ;84DF5B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_DraygonCannonShieldFacingDownRight_84DF5D:
     dw UNUSED_Setup_DraygonCannonWithShieldFacingDownUpRight_84DEB9      ;84DF5D;
     dw InstList_PLM_DraygonCannonWithShieldFacingDownRight_0             ;84DF5F;
@@ -13015,11 +13176,13 @@ UNUSED_PLMEntries_DraygonCannonShieldFacingDownRight_84DF5D:
 UNUSED_PLMEntries_DraygonCannonShieldFacingUpRight_84DF61:
     dw UNUSED_Setup_DraygonCannonWithShieldFacingDownUpRight_84DEB9      ;84DF61;
     dw UNUSED_InstList_DraygonCannonWithShieldFacingUpRight_84DD70       ;84DF63;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_DraygonCannonFacingRight:
     dw Setup_DraygonCannon                                               ;84DF65;
     dw InstList_PLM_DraygonCannonFacingRight_0                           ;84DF67;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_DraygonCannonFacingDownRight_84DF69:
     dw Setup_DraygonCannon                                               ;84DF69;
     dw UNUSED_InstList_PLM_DraygonCannonFacingDownRight_0                ;84DF6B;
@@ -13027,11 +13190,13 @@ UNUSED_PLMEntries_DraygonCannonFacingDownRight_84DF69:
 UNUSED_PLMEntries_DraygonCannonFacingUpRight_84DF6D:
     dw Setup_DraygonCannon                                               ;84DF6D;
     dw UNUSED_InstList_PLM_DraygonCannonFacingUpRight_84DDA3             ;84DF6F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_DraygonCannonWithShieldFacingLeft:
     dw Setup_DraygonCannonWithShieldFacingLeft                           ;84DF71;
     dw InstList_PLM_DraygonCannonWithShieldFacingLeft_0                  ;84DF73;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_DraygonCannonShieldFacingDownLeft_84DF75:
     dw UNUSED_Setup_DraygonCannonWithShieldFacingDownUpLeft_84DF15       ;84DF75;
     dw UNUSED_InstList_DraygonCannonWithShieldFacingDownLeft_84DE02      ;84DF77;
@@ -13039,11 +13204,13 @@ UNUSED_PLMEntries_DraygonCannonShieldFacingDownLeft_84DF75:
 UNUSED_PLMEntries_DraygonCannonWithShieldFacingUpLeft_84DF79:
     dw UNUSED_Setup_DraygonCannonWithShieldFacingDownUpLeft_84DF15       ;84DF79;
     dw UNUSED_InstList_DraygonCannonWithShieldFacingUpLeft_84DE4B        ;84DF7B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMEntries_DraygonCannonFacingLeft:
     dw Setup_DraygonCannon                                               ;84DF7D;
     dw InstList_PLM_DraygonCannonFacingLeft_0                            ;84DF7F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMEntries_DraygonCannonFacingDownLeft_84DF81:
     dw Setup_DraygonCannon                                               ;84DF81;
     dw UNUSED_InstList_PLM_DraygonCannonFacingDownLeft_84DE35            ;84DF83;
@@ -13051,6 +13218,7 @@ UNUSED_PLMEntries_DraygonCannonFacingDownLeft_84DF81:
 UNUSED_PLMEntries_DraygonCannonFacingUpLeft_84DF85:
     dw Setup_DraygonCannon                                               ;84DF85;
     dw UNUSED_InstList_PLM_DraygonCannonFacingUpLeft_84DE7E              ;84DF87;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PreInstruction_PLM_GotoLinkInstructionIfTriggered:
     LDA.W $1D77,X                                                        ;84DF89;

--- a/src/bank_85.asm
+++ b/src/bank_85.asm
@@ -249,8 +249,10 @@ Initialise_MessageBox:
     RTS                                                                  ;858257;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30_858258:
     REP #$30                                                             ;858258;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Write_Large_MessageBox_Tilemap:
     LDX.W #$0000                                                         ;85825A;

--- a/src/bank_86.asm
+++ b/src/bank_86.asm
@@ -268,6 +268,7 @@ Instruction_EnemyProjectile_CallExternalFunctionInY:
     JML.W [$0012]                                                        ;868188;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_EnemyProjectile_CallExternalFuncWith2ByteParam:
     LDA.W $0000,Y                                                        ;86818B;
     STA.B $12                                                            ;86818E;
@@ -287,6 +288,7 @@ UNUSED_Inst_EnemyProjectile_CallExternalFuncWith2ByteParam:
 
 .externalFunction:
     JML.W [$0012]                                                        ;8681A8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_GotoY:
@@ -322,11 +324,13 @@ Instruction_EnemyProjectile_DecrementTimer_GotoYIfNonZero:
     RTS                                                                  ;8681CD;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_EnemyProj_DecrementTimer_GotoY_YIfNonZero_8681CE:
     DEC.W $19DF,X                                                        ;8681CE;
     BNE Instruction_EnemyProjectile_GotoY_Y                              ;8681D1;
     INY                                                                  ;8681D3;
     RTS                                                                  ;8681D4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_TimerInY:
@@ -407,11 +411,13 @@ Instruction_EnemyProjectile_Properties_AndY:
     RTS                                                                  ;868247;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_EnemyProj_EnableCollisionWithSamusProj_868248:
     LDA.W $1BD7,X                                                        ;868248;
     ORA.W #$8000                                                         ;86824B;
     STA.W $1BD7,X                                                        ;86824E;
     RTS                                                                  ;868251;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_DisableCollisionWIthSamusProj:
@@ -428,6 +434,7 @@ Instruction_EnemyProjectile_DisableCollisionWithSamus:
     RTS                                                                  ;868265;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_EnemyProjectile_EnableCollisionWithSamus_868266:
     LDA.W $1BD7,X                                                        ;868266;
     AND.W #$DFFF                                                         ;868269;
@@ -447,6 +454,7 @@ UNUSED_Instruction_EnemyProjectile_SetToDieOnContact_86827A:
     AND.W #$BFFF                                                         ;86827D;
     STA.W $1BD7,X                                                        ;868280;
     RTS                                                                  ;868283;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_SetHighPriority:
@@ -456,11 +464,13 @@ Instruction_EnemyProjectile_SetHighPriority:
     RTS                                                                  ;86828D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_EnemyProjectile_SetLowPriority_86828E:
     LDA.W $1BD7,X                                                        ;86828E;
     AND.W #$EFFF                                                         ;868291;
     STA.W $1BD7,X                                                        ;868294;
     RTS                                                                  ;868297;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_XYRadiusInY:
@@ -471,9 +481,11 @@ Instruction_EnemyProjectile_XYRadiusInY:
     RTS                                                                  ;8682A0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_EnemyProjectile_XYRadius_0:
     STZ.W $1BB3,X                                                        ;8682A1;
     RTS                                                                  ;8682A4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_CalculateDirectionTowardsSamus:
@@ -500,6 +512,7 @@ Instruction_EnemyProjectile_CalculateDirectionTowardsSamus:
     RTS                                                                  ;8682D4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_EnemyProj_WriteColorsFromYToColorIndex_8682D5:
     PHY                                                                  ;8682D5;
     PHX                                                                  ;8682D6;
@@ -540,6 +553,7 @@ UNUSED_Inst_EnemyProjectile_QueueSoundInY_Lib1_Max6_868309:
     JSL.L QueueSound_Lib1_Max6                                           ;86830C;
     INY                                                                  ;868310;
     RTS                                                                  ;868311;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_QueueSoundInY_Lib2_Max6:
@@ -563,6 +577,7 @@ Instruction_EnemyProjectile_QueueSoundInY_Lib1_Max15:
     RTS                                                                  ;86832C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_EnemyProjectile_QueueSoundInY_Lib2_Max15_86832D:
     LDA.W $0000,Y                                                        ;86832D;
     JSL.L QueueSound_Lib2_Max15                                          ;868330;
@@ -624,6 +639,7 @@ UNUSED_Inst_EnemyProjectile_QueueSoundInY_Lib1_Max1_868375:
     JSL.L QueueSound_Lib1_Max1                                           ;868378;
     INY                                                                  ;86837C;
     RTS                                                                  ;86837D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnemyProjectile_QueueSoundInY_Lib2_Max1:
@@ -804,11 +820,13 @@ RTS_8684FB:
 InstList_EnemyProjectile_Delete:
     dw Instruction_EnemyProjectile_Delete                                ;8684FC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_BlankSpritemap:
     dw $1000                                                             ;8684FE;
     dw EnemyProjSpritemaps_Blank_Default                                 ;868500;
     dw Instruction_EnemyProjectile_GotoY                                 ;868502;
     dw UNUSED_InstList_EnemyProjectile_BlankSpritemap                    ;868504;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjectile_BlockCollision_HorizontalExtension:
     LDX.W $0DC4                                                          ;868506;
@@ -1656,6 +1674,7 @@ Move_EnemyProjectile_Vertically:
     RTS                                                                  ;868A38;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_868A39:
     JSL.L GenerateRandomNumber                                           ;868A39;
     LDX.W $0E54                                                          ;868A3D;
@@ -1725,6 +1744,7 @@ UNUSED_EnemyProjectile_868AAF:
     db $00,$00                                                           ;868AB5;
     dw $0002,$0000                                                       ;868AB7;
     dw InstList_EnemyProjectile_Delete                                   ;868ABB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_SkreeParticle:
     dw $0010                                                             ;868ABD;
@@ -1925,10 +1945,12 @@ EnemyProjectile_MetalSkreeParticles_UpLeft:
     dw $0004,$0000                                                       ;868C2C;
     dw InstList_EnemyProjectile_Delete                                   ;868C30;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Draygon_868C32:
     dw $0010                                                             ;868C32;
     dw UNUSED_EnemyProjSpritemaps_Draygon_8D8A0F                         ;868C34;
     dw Instruction_EnemyProjectile_Sleep                                 ;868C36;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_DraygonGoop_Touch:
     dw Instruction_DraygonGoop_SamusCollision                            ;868C38;
@@ -1974,6 +1996,7 @@ Instruction_SpawnEnemyDropsWIthDraygonEyeDropChances:
     RTS                                                                  ;868C7D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Draygon_868C7E:
     dw $0004                                                             ;868C7E;
     dw UNUSED_EnemyProjSpritemaps_Draygon_0_8D8A32                       ;868C80;
@@ -1994,6 +2017,7 @@ UNUSED_InstList_Draygon_868C7E:
     dw Instruction_EnemyProjectile_GotoY                                 ;868C9E;
     dw UNUSED_InstList_Draygon_868C7E                                    ;868CA0;
     dw Instruction_EnemyProjectile_Sleep                                 ;868CA2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_DraygonsWallTurretProjectile_0:
     dw $0005                                                             ;868CA4;
@@ -2046,10 +2070,12 @@ Instruction_SetPreInst_DraygonsWallTurretProjectile_Fired:
     RTS                                                                  ;868CFC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_PreInstruction_DraygonGoop_StuckToSamus_868CFD:
     LDA.W #PreInstruction_DraygonGoop_StuckToSamus                       ;868CFD;
     STA.W $1A03,X                                                        ;868D00;
     RTS                                                                  ;868D03;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProjectile_DraygonGoop:
@@ -2098,10 +2124,12 @@ RTS_868D54:
     RTS                                                                  ;868D54;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Delete_EnemyProjectile_Y_868D55:
     LDA.W #$0000                                                         ;868D55;
     STA.W $1997,Y                                                        ;868D58;
     RTS                                                                  ;868D5B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Delete_EnemyProjectile_IfPowerBombed:
@@ -2263,6 +2291,7 @@ EnemyProjectile_DraygonWallTurret:
     dw $0000                                                             ;868E68;
     dw InstList_EnemyProj_MiscDust_3_SmallExplosion                      ;868E6A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_Draygon_868E6C:
     dw UNUSED_InitAI_EnemyProjectile_Draygon_868E7A                      ;868E6C;
     dw UNUSED_PreInstruction_EnemyProjectile_Draygon_868E99              ;868E6E;
@@ -2425,6 +2454,7 @@ UNUSED_EnemyProjectile_InstListPointers_868F7F:
     dw UNUSED_InstList_EnemyProjectile_868F43                            ;868F89;
     dw UNUSED_InstList_EnemyProjectile_868F57                            ;868F8B;
     dw UNUSED_InstList_EnemyProjectile_868F6B                            ;868F8D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjectile_CrocomiresProjectile:
     dw InitAI_EnemyProjectile_CrocomiresProjectile                       ;868F8F;
@@ -2444,6 +2474,7 @@ EnemyProjectile_CrocomireBridgeCrumbling:
     dw $0000                                                             ;868FA7;
     dw InstList_EnemyProjectile_Delete                                   ;868FA9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_CrocomiresProjectile_Part1_868FAB:
     dw $0005                                                             ;868FAB;
     dw EnemyProjSpritemaps_CrocomiresProjectile_0                        ;868FAD;
@@ -2467,6 +2498,7 @@ UNUSED_InstList_EnemyProj_OldCrocomiresProjectile_868FC3:
     dw UNUSED_EnemyProjSpritemaps_OldCrocomiresProjectile_1_8D8098       ;868FC9;
     dw Instruction_EnemyProjectile_GotoY                                 ;868FCB;
     dw UNUSED_InstList_EnemyProj_OldCrocomiresProjectile_868FC3          ;868FCD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_CrocomiresProjectile:
     dw $0003                                                             ;868FCF;
@@ -2496,6 +2528,7 @@ InstList_EnemyProjectile_CrocomireSpikeWallPieces:
     dw Instruction_EnemyProjectile_GotoY                                 ;868FF7;
     dw InstList_EnemyProjectile_CrocomireSpikeWallPieces                 ;868FF9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_CrocomireBridgeCrumbling_868FFB:
     dw $0002                                                             ;868FFB;
     dw UNUSED_EnemyProjSpritemaps_CrocomireBridgeCrumbling_0_8D8132      ;868FFD;
@@ -2503,6 +2536,7 @@ UNUSED_InstList_EnemyProj_CrocomireBridgeCrumbling_868FFB:
     dw UNUSED_EnemyProjSpritemaps_CrocomireBridgeCrumbling_1_8D813E      ;869001;
     dw $7FFF                                                             ;869003;
     dw UNUSED_EnemyProjSpritemaps_CrocomireBridgeCrumbling_2_8D815E      ;869005;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_Shot_CrocomiresProjectile:
     dw $0004                                                             ;869007;
@@ -2724,6 +2758,7 @@ PreInstruction_EnemyProjectile_CrocomireSpikeWallPieces:
     dw $0001,$0001,$0006,$0005,$0004,$0003,$0002,$0002                   ;86921B;
     dw $0001,$0001                                                       ;86922B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveEnemyProjectileUpFor6FramesThenDelete_86922F:
     LDA.W $0B64,X                                                        ;86922F;
     LDA.W #$0001                                                         ;869232;
@@ -2753,6 +2788,7 @@ UNUSED_PreInstruction_EnemyProjectile_MovingUp_869259:
 
 .return:
     RTS                                                                  ;86926F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_SpawnEnemyDropsWithCrocomiresDropChances:
@@ -2884,6 +2920,7 @@ Set_RidleysFireball_Afterburn_Damage:
     RTS                                                                  ;86934C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitAI_EnemyProj_RidleysFireball_Afterburn_86934D:
     LDA.W #$0000                                                         ;86934D;
     STA.W $1AFF,Y                                                        ;869350;
@@ -2942,6 +2979,7 @@ UNUSED_PreInst_EnemyProj_RidleyFireball_Afterburn_869392:
     LDA.W #$002B                                                         ;8693C2;
     JSL.L QueueSound_Lib2_Max6                                           ;8693C5;
     RTS                                                                  ;8693C9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProjectile_RidleyFireball:
@@ -3017,6 +3055,7 @@ PreInstruction_EnemyProjectile_RidleyFireball:
     RTS                                                                  ;869441;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DoFireballDamageToSamus_TurnIntoSmoke_869442:
     LDA.W #UNUSED_InstList_Smoke_86945F                                  ;869442;
     STA.W $1B47,X                                                        ;869445;
@@ -3050,6 +3089,7 @@ UNUSED_Instruction_DisableCollisionsWithSamus_869475:
     ORA.W #$2000                                                         ;869478;
     STA.W $1BD7,X                                                        ;86947B;
     RTS                                                                  ;86947E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProjectile_Afterburn_Center:
@@ -3149,6 +3189,7 @@ PreInstruction_EnemyProjectile_VerticalAfterburn:
     RTS                                                                  ;869536;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PreInstruction_ProtoHorizontalAfterburn_869537:
     JSR.W Move_EnemyProjectile_Horizontally                              ;869537;
     BCC .return                                                          ;86953A;
@@ -3174,6 +3215,7 @@ UNUSED_PreInstruction_ProtoVerticalAfterburn_Down_869549:
 
 .return:
     RTS                                                                  ;869551;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_EnemyProjectile_RidleysFireball_0:
@@ -3211,6 +3253,7 @@ InstList_EnemyProjectile_Afterburn_Final:
     dw EnemyProjSpritemaps_RidleysFireball_MBBombExplosion_4             ;869588;
     dw Instruction_EnemyProjectile_Delete                                ;86958A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_86958C:
     dw $0002                                                             ;86958C;
     dw UNUSED_EnemyProjSpritemaps_0_8D80AE                               ;86958E;
@@ -3222,6 +3265,7 @@ UNUSED_InstList_EnemyProjectile_86958C:
     dw UNUSED_EnemyProjSpritemaps_3_8D80C3                               ;86959A;
     dw Instruction_EnemyProjectile_GotoY                                 ;86959C;
     dw UNUSED_InstList_EnemyProjectile_86958C                            ;86959E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_HorizontalAfterburn_Center:
     dw Instruction_EnemyProjectile_ClearPreInstruction                   ;8695A0;
@@ -3311,6 +3355,7 @@ Instruction_SpawnNext_Afterburn_EnemyProjectile:
     RTS                                                                  ;869633;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_Ridley_869634:
     dw UNUSED_InitAI_EnemyProj_RidleysFireball_Afterburn_86934D          ;869634;
     dw UNUSED_PreInst_EnemyProj_RidleyFireball_Afterburn_869392          ;869636;
@@ -3319,6 +3364,7 @@ UNUSED_EnemyProjectile_Ridley_869634:
     dw $1003                                                             ;86963C;
     dw $0000                                                             ;86963E;
     dw InstList_EnemyProjectile_Delete                                   ;869640;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjectile_RidleysFireball:
     dw InitAI_EnemyProjectile_RidleyFireball                             ;869642;
@@ -3383,6 +3429,7 @@ EnemyProjectile_RidleyVerticalAfterburn_Down:
     dw $0000                                                             ;8696A0;
     dw InstList_EnemyProjectile_Delete                                   ;8696A2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_RidleyProtoHorizontalAfterburn_8696A4:
     dw InitAI_EnemyProjectile_HorizontalAfterburn_Right                  ;8696A4;
     dw UNUSED_PreInstruction_ProtoHorizontalAfterburn_869537             ;8696A6;
@@ -3418,6 +3465,7 @@ UNUSED_EnemyProjectile_RidleyProtoVerticalAfterburn_8696CE:
     dw $5003                                                             ;8696D6;
     dw $0000                                                             ;8696D8;
     dw InstList_EnemyProjectile_Delete                                   ;8696DA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_EnemyProjectile_CeresFallingTile:
     LDA.W #$0000                                                         ;8696DC;
@@ -5387,12 +5435,14 @@ InstList_EnemyProj_BombTorizoLowHealthDrool_HitFloor:
     dw UNUSED_EnemyProjSpritemaps_BombTorizoLowHealthDrool_3_8D8C69      ;86A49A;
     dw Instruction_EnemyProjectile_Delete                                ;86A49C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_BombTorizo_86A49E:
     dw Instruction_EnemyProjectile_Properties_OrY                        ;86A49E;
     dw $3000,$0024                                                       ;86A4A0;
     dw UNUSED_EnemyProjSpritemaps_BombTorizoLowHealthDrool_0_8D8C54      ;86A4A4;
     dw Instruction_EnemyProjectile_GotoY                                 ;86A4A6;
     dw InstList_EnemyProj_BombTorizoLowHealthDrool_HitFloor              ;86A4A8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_BombTorizoExplosionSwipe:
     dw Instruction_EnemyProjectile_QueueSoundInY_Lib2_Max1               ;86A4AA;
@@ -5709,6 +5759,7 @@ InitAI_EnemyProjectile_BombTorizoInitialDrool:
     RTS                                                                  ;86A6C6;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitAI_EnemyProjectile_BombTorizo_86A6C7:
     LDA.W #$0000                                                         ;86A6C7;
     STA.W $19BB,Y                                                        ;86A6CA;
@@ -5732,6 +5783,7 @@ UNUSED_InitAI_EnemyProjectile_BombTorizo_86A6C7:
     STA.W $1A27,Y                                                        ;86A6EF;
     STA.W $1A6F,Y                                                        ;86A6F2;
     RTS                                                                  ;86A6F5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProjectile_BombTorizoExplosiveSwipe:
@@ -5982,6 +6034,7 @@ RTS_86A919:
     RTS                                                                  ;86A919;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Debug_MoveEnemyProjectileWithController2:
     STZ.W $1AB7,X                                                        ;86A91A;
     LDA.B $8D                                                            ;86A91D;
@@ -6016,6 +6069,7 @@ UNUSED_Debug_MoveEnemyProjectileWithController2:
 .moveVertically:
     JSR.W Move_EnemyProjectile_Vertically                                ;86A957;
     RTS                                                                  ;86A95A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EnemyProjectile_BombTorizoContinuousDrool:
@@ -6036,6 +6090,7 @@ EnemyProjectile_BombTorizoInitialDrool:
     dw $0000                                                             ;86A973;
     dw InstList_EnemyProjectile_Delete                                   ;86A975;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_BombTorizo_86A977:
     dw UNUSED_InitAI_EnemyProjectile_BombTorizo_86A6C7                   ;86A977;
     dw PreInst_EnemyProjectile_BombTorizoChozoBreaking_Falling           ;86A979;
@@ -6044,6 +6099,7 @@ UNUSED_EnemyProjectile_BombTorizo_86A977:
     dw $3000                                                             ;86A97F;
     dw $0000                                                             ;86A981;
     dw InstList_EnemyProjectile_Delete                                   ;86A983;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjectile_BombTorizoExplosiveSwipe:
     dw InitAI_EnemyProjectile_BombTorizoExplosiveSwipe                   ;86A985;
@@ -6082,6 +6138,7 @@ EnemyProjectile_BombTorizoDeathExplosion:
     dw InstList_EnemyProjectile_Delete                                   ;86A9BB;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_Graphics_QuestionMark_86A9BD:
 incbin "../data/Tiles_EnemyProj_QuestionMark.bin" ; $80 bytes
 
@@ -6202,6 +6259,7 @@ UNUSED_EnemyProjectile_QuestionMark_86AB07:
     db $00,$00                                                           ;86AB0D;
     dw $B000,$0000                                                       ;86AB0F;
     dw UNUSED_InstList_EnemyProjectile_Shot_QuestionMark_86AAF2          ;86AB13;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_TorizoChozoOrbs_Left:
     dw $0055                                                             ;86AB15;
@@ -6352,6 +6410,7 @@ InitAI_EnemyProjectile_BombTorizoChozoOrbs:
     dw InstList_EnemyProjectile_TorizoChozoOrbs_Left                     ;86AC12;
     dw $FFE5,$FE70,$FFD8,$FE60                                           ;86AC14;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitializeTorizoChozoOrbToTargetSamus:
     JSL.L GenerateRandomNumber                                           ;86AC1C;
     LDX.W $0E54                                                          ;86AC20;
@@ -6395,6 +6454,7 @@ UNUSED_InitializeTorizoChozoOrbToTargetSamus:
     LDA.W #InstList_EnemyProjectile_TorizoChozoOrbs_Right                ;86AC75;
     STA.W $1B47,Y                                                        ;86AC78;
     RTS                                                                  ;86AC7B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProjectile_GoldenTorizosChozoOrbs:
@@ -6551,6 +6611,7 @@ EnemyProjectile_GoldenTorizoChozoOrbs:
     dw $0000                                                             ;86AD84;
     dw InstList_EnemyProjectile_Shot_TorizoChozoOrbs                     ;86AD86;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_86AD88:
     dw Instruction_EnemyProjectile_PreInstructionInY                     ;86AD88;
     dw PreInstruction_EnemyProjectile_TorizoSonicBoom                    ;86AD8A;
@@ -6584,6 +6645,7 @@ UNUSED_Instruction_EnemyProj_MoveHorizontally_GotoY_86AD92:
     LDA.W $0002,Y                                                        ;86ADBA;
     TAY                                                                  ;86ADBD;
     RTS                                                                  ;86ADBE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_EnemyProjectile_TorizoSonicBoom_FiredLeft:
@@ -6751,6 +6813,7 @@ InstList_EnemyProj_WreckedShipChozoSpikeClearingFootsteps:
     dw EnemyProjSpritemaps_Common_BigDustCloud_3                         ;86AED8;
     dw Instruction_EnemyProjectile_Delete                                ;86AEDA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_SpikeClearingExplosions_86AEDC:
     dw Instruction_MoveRandomlyWithinXRadius_YRadius                     ;86AEDC;
     db $0F,$00,$0F,$03                                                   ;86AEDE;
@@ -6767,6 +6830,7 @@ UNUSED_InstList_EnemyProj_SpikeClearingExplosions_86AEDC:
     dw $0005                                                             ;86AEF6;
     dw EnemyProjSpritemaps_Common_BigExplosion_5                         ;86AEF8;
     dw Instruction_EnemyProjectile_Delete                                ;86AEFA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_EnemyProj_WreckedShipChozoSpikeClearingFootsteps:
     LDX.W $0E54                                                          ;86AEFC;
@@ -6838,6 +6902,7 @@ EnemyProjectile_WreckedShipChozoSpikeClearingFootsteps:
     dw $3000,$0000                                                       ;86AF70;
     dw InstList_EnemyProjectile_Delete                                   ;86AF74;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_SpikeClearingExplosions_86AF76:
     dw InitAI_EnemyProj_WreckedShipChozoSpikeClearingFootsteps           ;86AF76;
     dw RTS_8684FB                                                        ;86AF78;
@@ -6845,6 +6910,7 @@ UNUSED_EnemyProjectile_SpikeClearingExplosions_86AF76:
     db $00,$00                                                           ;86AF7C;
     dw $3000,$0000                                                       ;86AF7E;
     dw InstList_EnemyProjectile_Delete                                   ;86AF82;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjectile_TourianStatueDustClouds:
     dw InitAI_EnemyProjectile_TourianStatueDustClouds                    ;86AF84;
@@ -7155,6 +7221,7 @@ InstList_EnemyProjectile_GoldenTorizoEgg_Hatched_Right_1:
     dw Instruction_EnemyProjectile_GotoY                                 ;86B17D;
     dw InstList_EnemyProjectile_GoldenTorizoEgg_Hatched_Right_1          ;86B17F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_Break_86B181:
     dw UNUSED_Instruction_EnemyProjectile_GotoBreak_86B183               ;86B181;
 
@@ -7168,6 +7235,7 @@ UNUSED_Instruction_EnemyProjectile_GotoBreak_86B183:
 .facingRight:
     LDY.W #InstList_EnemyProjectile_GoldenTorizoEgg_Break_FacingRight    ;86B18C;
     RTS                                                                  ;86B18F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_EnemyProjectile_GoldenTorizoEgg_Break_FacingLeft:
@@ -7573,12 +7641,14 @@ EnemyProjectile_GoldenTorizoEyeBeam:
     dw $700A,$0000                                                       ;86B430;
     dw InstList_EnemyProjectile_Delete                                   ;86B434;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_ResetPosition_86B436:
     LDA.W $1AFF,X                                                        ;86B436;
     STA.W $1A4B,X                                                        ;86B439;
     LDA.W $1B23,X                                                        ;86B43C;
     STA.W $1A93,X                                                        ;86B43F;
     RTS                                                                  ;86B442;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_EnemyProj_OldTourianEscapeShaftFakeWallExplosion_0:
@@ -7607,6 +7677,7 @@ InstList_EnemyProj_OldTourianEscapeShaftFakeWallExplosion_1:
     dw InstList_EnemyProj_OldTourianEscapeShaftFakeWallExplosion_1       ;86B46C;
     dw Instruction_EnemyProjectile_Delete                                ;86B46E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_86B470:
     dw Instruction_EnemyProjectile_QueueSoundInY_Lib2_Max6               ;86B470;
     db $24                                                               ;86B472;
@@ -7636,6 +7707,7 @@ UNUSED_Instruction_GotoY_Probability_1_4:
     LDA.W $0000,Y                                                        ;86B498;
     TAY                                                                  ;86B49B;
     RTS                                                                  ;86B49C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProj_OldTourianEscapeShaftFakeWallExplosion:
@@ -8038,11 +8110,13 @@ EnemyProjectile_EyeDoorSweat:
     dw $0000                                                             ;86B75B;
     dw InstList_EnemyProjectile_Delete                                   ;86B75D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Colors_86B75F:
     dw $5294,$39CE,$2108,$2484,$35AD,$2529,$14A5,$1842                   ;86B75F;
     dw $2108,$1084,$14A5,$1842,$0C63,$0421,$0842,$0000                   ;86B76F;
     dw $5294,$39CE,$2108,$2484,$5294,$39CE,$2108,$2484                   ;86B77F;
     dw $5294,$39CE,$2108,$2484,$5294,$39CE,$2108,$2484                   ;86B78F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_TourianStatue_Delete:
     dw Instruction_EnemyProjectile_Delete                                ;86B79F;
@@ -8500,6 +8574,7 @@ EnemyProjectile_TourianStatueBaseDecoration:
     dw $0000                                                             ;86BAC8;
     dw InstList_EnemyProjectile_Delete                                   ;86BACA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_Parameter0_86BACC:
     dw $0002                                                             ;86BACC;
     dw UNUSED_EnemyProjSpritemaps_0_8D9268                               ;86BACE;
@@ -8575,12 +8650,14 @@ UNUSED_InitAI_EnemyProjectile_86BB30:
     PLY                                                                  ;86BB4A;
     STA.W $1B47,Y                                                        ;86BB4B;
     RTS                                                                  ;86BB4E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_86BB4F:
     RTS                                                                  ;86BB4F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_86BB50:
     dw UNUSED_InitAI_EnemyProjectile_86BB30                              ;86BB50;
     dw RTS_86BB4F                                                        ;86BB52;
@@ -8588,6 +8665,7 @@ UNUSED_EnemyProjectile_86BB50:
     db $00,$00                                                           ;86BB56;
     dw $0000,$7000                                                       ;86BB58;
     dw InstList_EnemyProjectile_Delete                                   ;86BB5C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_PuromiBody:
     dw $0003                                                             ;86BB5E;
@@ -10213,8 +10291,10 @@ InitAI_EnemyProjectile_MotherBrainRedBeam_Fired:
     RTS                                                                  ;86C75C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 .unused:
     dw $0002,$FFFE,$0002,$FFFE,$FFFE,$0002,$FFFE,$0002                   ;86C75D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RTS_86C76D:
     RTS                                                                  ;86C76D;
@@ -10417,10 +10497,12 @@ Instruction_EnemyProj_MotherBrainsDrool_MoveDownCPixels:
     RTS                                                                  ;86C8DA;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_MotherBrainsDrool_86C8DB:
     dw $000A                                                             ;86C8DB;
     dw EnemyProjSpritemaps_MotherBrainsDrool_2                           ;86C8DD;
     dw Instruction_EnemyProjectile_Sleep                                 ;86C8DF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_MotherBrainsDrool_HitFloor:
     dw Instruction_EnemyProjectile_ClearPreInstruction                   ;86C8E1;
@@ -10593,6 +10675,7 @@ InstList_EnemyProj_MotherBrainExplodedEscapeDoorParticle:
     dw Instruction_EnemyProjectile_GotoY                                 ;86CA42;
     dw InstList_EnemyProj_MotherBrainExplodedEscapeDoorParticle          ;86CA44;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_86CA46:
     dw $0001                                                             ;86CA46;
     dw UNUSED_EnemyProjSpritemaps_0_8D96D3                               ;86CA48;
@@ -10612,6 +10695,7 @@ UNUSED_InstList_86CA46:
     dw UNUSED_EnemyProjSpritemaps_7_8D9704                               ;86CA64;
     dw Instruction_EnemyProjectile_GotoY                                 ;86CA66;
     dw UNUSED_InstList_86CA46                                            ;86CA68;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_EnemyProjectile_MotherBrainPurpleBreath_Big:
     TYX                                                                  ;86CA6A;
@@ -10883,8 +10967,10 @@ MotherBrainsTubeFallingFunction_Falling:
     RTS                                                                  ;86CC32;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_86CC33:
     dw $FF00,$0100,$0100,$0000,$FF00,$FF00,$0100,$0000                   ;86CC33;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_MotherBrainsTubeFalling_TopRight:
     dw $0001                                                             ;86CC43;
@@ -13296,6 +13382,7 @@ InitAI_EnemyProjectile_SporeSpawnsStalk:
 .data:
     dw $FFC0,$FFC8,$FFD0,$FFD8,$FFE0                                     ;86DCB9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitAI_EnemyProjectile_SporeSpawnsStalk_86DCC3:
     LDA.W $0F7E                                                          ;86DCC3;
     CLC                                                                  ;86DCC6;
@@ -13304,6 +13391,7 @@ UNUSED_InitAI_EnemyProjectile_SporeSpawnsStalk_86DCC3:
     LDA.W $0F7A                                                          ;86DCCD;
     STA.W $1A4B,Y                                                        ;86DCD0;
     RTS                                                                  ;86DCD3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitAI_EnemyProjectile_SporeSpawner:
@@ -13566,6 +13654,7 @@ Delete_EnemyProjectile_ifOffScreen_duplicate_again:
     RTS                                                                  ;86DF9F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CheckIf_EnemyProj_isHorizontallyOffScreen_86DFA0:
     LDA.W $1A4B,X                                                        ;86DFA0;
     CMP.W $0911                                                          ;86DFA3;
@@ -13582,6 +13671,7 @@ UNUSED_CheckIf_EnemyProj_isHorizontallyOffScreen_86DFA0:
 .returnOffScreen:
     LDA.W #$0001                                                         ;86DFB8;
     RTS                                                                  ;86DFBB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EnemyProjectile_NamiheFireball:
@@ -14368,6 +14458,7 @@ EnemyProjectile_MiscDustPLM:
     dw $0000,$0000                                                       ;86E51F;
     dw InstList_EnemyProjectile_Delete                                   ;86E523;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjectile_DustCloudExplosion_86E525:
     dw InitAI_EnemyProj_MiscDust                                         ;86E525;
     dw InstList_EnemyProjectile_GunshipLiftoffDustClouds_Index0_0        ;86E527; >_< this is not a pre-instruction, its an instruction list
@@ -14375,6 +14466,7 @@ UNUSED_EnemyProjectile_DustCloudExplosion_86E525:
     db $00,$00                                                           ;86E52B;
     dw $0000,$0000                                                       ;86E52D;
     dw InstList_EnemyProjectile_Delete                                   ;86E531;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_EnemyProjectile_ShotGate_EnemyVelocityInY:
     LDA.W $0000,Y                                                        ;86E533;
@@ -14779,6 +14871,7 @@ PlaceAndAim_DraygonsWallTurretProjectile:
     RTS                                                                  ;86E7FA;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_BotwoonsBody_UpFacingLeft_86E7FB:
     dw $0008                                                             ;86E7FB;
     dw EnemyProjSpritemaps_BotwoonsBody_UpFacingLeft_0                   ;86E7FD;
@@ -14790,6 +14883,7 @@ UNUSED_InstList_EnemyProj_BotwoonsBody_UpFacingLeft_86E7FB:
     dw EnemyProjSpritemaps_BotwoonsBody_UpFacingLeft_3                   ;86E809;
     dw Instruction_EnemyProjectile_GotoY                                 ;86E80B;
     dw UNUSED_InstList_EnemyProj_BotwoonsBody_UpFacingLeft_86E7FB        ;86E80D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_BotwoonsBody_UpLeft:
     dw $0008                                                             ;86E80F;
@@ -14827,6 +14921,7 @@ InstList_EnemyProjectile_BotwoonsBody_DownLeft:
     dw Instruction_EnemyProjectile_GotoY                                 ;86E847;
     dw InstList_EnemyProjectile_BotwoonsBody_DownLeft                    ;86E849;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_BotwoonsBody_DownFacingLeft_86E84B:
     dw $0008                                                             ;86E84B;
     dw UNUSED_EnemyProjSpritemap_BotwoonsBody_DownFacingLeft_8DB682      ;86E84D;
@@ -14838,6 +14933,7 @@ UNUSED_InstList_EnemyProj_BotwoonsBody_DownFacingLeft_86E84B:
     dw UNUSED_EnemyProjSpritemap_BotwoonsBody_DownFacingLeft_8DB697      ;86E859;
     dw Instruction_EnemyProjectile_GotoY                                 ;86E85B;
     dw UNUSED_InstList_EnemyProj_BotwoonsBody_DownFacingLeft_86E84B      ;86E85D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_BotwoonsBody_Down_FacingRight:
     dw $0008                                                             ;86E85F;
@@ -14944,6 +15040,7 @@ InstList_EnemyProjectile_BotwoonsBodyTail_Hidden:
     dw EnemyProjSpritemaps_BotwoonsBody_28                               ;86E8F5;
     dw Instruction_EnemyProjectile_Sleep                                 ;86E8F7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_BotwoonsBodyTail_86E8F9:
     dw $0008                                                             ;86E8F9;
     dw UNUSED_EnemyProjSpritemaps_BotwoonsBodyTail_0_8DB762              ;86E8FB;
@@ -15103,6 +15200,7 @@ UNUSED_InstList_EnemyProjectile_BotwoonsBodyTail_86E9EB:
     dw $0001                                                             ;86E9EB;
     dw UNUSED_EnemyProjSpritemaps_BotwoonsBodyTail_2F_8DB8AB             ;86E9ED;
     dw Instruction_EnemyProjectile_Sleep                                 ;86E9EF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 BotwoonsBodyTail_InstListPointers:
     dw InstList_EnemyProjectile_BotwoonsBody_Up_FacingRight              ;86E9F1;
@@ -15614,12 +15712,14 @@ InstList_EnemyProjectile_EnemyDeathExplosion_SmallExplosion:
     dw Instruction_EnemyProjectile_EnemyDeathExplosion_BecomePickup      ;86ED83;
     dw Instruction_EnemyProjectile_Delete                                ;86ED85;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_EnemyDeathExplo_GotoDelete_86ED87:
     dw Instruction_EnemyProjectile_GotoY                                 ;86ED87;
     dw InstList_EnemyProjectile_Delete                                   ;86ED89;
 
 UNUSED_InstList_EnemyProj_EnemyDeathExplosion_Delete_86ED8B:
     dw Instruction_EnemyProjectile_Delete                                ;86ED8B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_Pickup_SmallEnergy:
     dw $0008                                                             ;86ED8D;
@@ -15656,6 +15756,7 @@ InstList_EnemyProjectile_Pickup_Missiles:
     dw InstList_EnemyProjectile_Pickup_Missiles                          ;86EDC3;
     dw Instruction_EnemyProjectile_Sleep                                 ;86EDC5;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProjectile_Pickup_Bombs_86EDC7:
     dw $0005                                                             ;86EDC7;
     dw UNUSED_EnemyProjSpritemaps_Pickup_Bombs_0_8DC0C9                  ;86EDC9;
@@ -15668,6 +15769,7 @@ UNUSED_InstList_EnemyProjectile_Pickup_Bombs_86EDC7:
     dw Instruction_EnemyProjectile_GotoY                                 ;86EDD7;
     dw UNUSED_InstList_EnemyProjectile_Pickup_Bombs_86EDC7               ;86EDD9;
     dw Instruction_EnemyProjectile_Sleep                                 ;86EDDB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_EnemyProjectile_Pickup_SuperMissiles:
     dw $0005                                                             ;86EDDD;
@@ -15727,6 +15829,7 @@ InstList_EnemyProj_EnemyDeathExplosion_KilledBySamusContact:
     dw Instruction_EnemyProjectile_EnemyDeathExplosion_BecomePickup      ;86EE41;
     dw Instruction_EnemyProjectile_Delete                                ;86EE43;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EnemyProj_EnemyDeathExplo_KillContact_86EE45:
     dw $0002                                                             ;86EE45;
     dw UNUSED_EnemyProjSpritemaps_EDeathExplo_KillContact_0_8DB8E5       ;86EE47;
@@ -15763,6 +15866,7 @@ UNUSED_InstList_EnemyProj_EnemyDeathExplo_KillContact_86EE45:
     dw UNUSED_EnemyProjSpritemaps_EDeathExplo_KillContact_F_8DBA61       ;86EE85;
     dw Instruction_EnemyProjectile_EnemyDeathExplosion_BecomePickup      ;86EE87;
     dw Instruction_EnemyProjectile_Delete                                ;86EE89;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_EnemyProj_EnemyDeathExpl_QueueEnemyKilledSoundFX:
     PHX                                                                  ;86EE8B;

--- a/src/bank_87.asm
+++ b/src/bank_87.asm
@@ -145,6 +145,7 @@ Instruction_AnimatedTilesObject_GotoY:
     RTS                                                                  ;8780BB;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_AnimatedTilesObject_GotoYPlusY_8780BC:
     STY.W $1F49                                                          ;8780BC;
     DEY                                                                  ;8780BF;
@@ -245,6 +246,7 @@ UNUSED_Instruction_AnimatedTilesObject_SetBossBitsY_878133:
     JSL.L SetBossBitsInAForCurrentArea                                   ;878139;
     INY                                                                  ;87813D;
     RTS                                                                  ;87813E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_AnimatedTilesObject_GotoYIfEventYSet:
@@ -270,6 +272,7 @@ Instruction_AnimatedTilesObject_SetEventY:
     RTS                                                                  ;878159;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_AnimatedTilesObject_LockSamus_87815A:
     LDA.W #$0000                                                         ;87815A;
     JSL.L Run_Samus_Command                                              ;87815D;
@@ -280,6 +283,7 @@ UNUSED_Instruction_AnimatedTilesObject_UnlockSamus_878162:
     LDA.W #$0001                                                         ;878162;
     JSL.L Run_Samus_Command                                              ;878165;
     RTS                                                                  ;878169;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_AnimatedTilesObject_VerticalSpikes:
@@ -446,9 +450,11 @@ UNUSED_AnimatedTilesObjects_FX_unusedCrateriaLava_0_878263:
     dw UNUSED_InstList_AnimatedTilesObject_CrateriaLava_8781A6           ;878263;
     dw $00C0,$0A00                                                       ;878265;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AnimatedTilesObjects_FX_unusedCrateriaLava_1_878269:
     dw UNUSED_InstList_AnimatedTilesObject_CrateriaLava_8781A6           ;878269;
     dw $00C0,$0640                                                       ;87826B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AnimatedTilesObjects_FX_wreckedShipScreen:
     dw InstList_AnimatedTilesObject_WreckedShipScreen_0                  ;87826F;
@@ -952,8 +958,10 @@ incbin "../data/AnimatedTiles_WreckedShipScreen_1.bin" ; $80 bytes
 AnimatedTiles_WreckedShipScreen_2:
 incbin "../data/AnimatedTiles_WreckedShipScreen_2.bin" ; $80 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AnimatedTiles_X_879064:
 incbin "../data/AnimatedTiles_X_879064.bin" ; $100 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AnimatedTiles_MaridiaSandFalling_0:
 incbin "../data/AnimatedTiles_MaridiaSandFalling_0.bin" ; $20 bytes
@@ -979,8 +987,10 @@ incbin "../data/AnimatedTiles_MaridiaSandCeiling_2.bin" ; $40 bytes
 AnimatedTiles_MaridiaSandCeiling_3:
 incbin "../data/AnimatedTiles_MaridiaSandCeiling_3.bin" ; $40 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AnimatedTiles_X_8792E4:
 incbin "../data/AnimatedTiles_X_8792E4.bin" ; $80 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AnimatedTiles_PhantoonStatue_0:
 incbin "../data/AnimatedTiles_PhantoonStatue_0.bin" ; $80 bytes
@@ -1057,8 +1067,10 @@ incbin "../data/AnimatedTiles_HorizontalSpikes_1.bin" ; $80 bytes
 AnimatedTiles_HorizontalSpikes_2:
 incbin "../data/AnimatedTiles_HorizontalSpikes_2.bin" ; $80 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AnimatedTiles_X_879F04:
 incbin "../data/AnimatedTiles_X_879F04.bin" ; $660 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AnimatedTiles_Lava_0:
 incbin "../data/AnimatedTiles_Lava_0.bin" ; $40 bytes

--- a/src/bank_88.asm
+++ b/src/bank_88.asm
@@ -623,6 +623,7 @@ RTL_8883E1:
     RTL                                                                  ;8883E1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpawnHDMAObject_Slot0_Channel4_Index20_8883E2:
     PHP                                                                  ;8883E2;
     PHB                                                                  ;8883E3;
@@ -645,6 +646,7 @@ UNUSED_SpawnHDMAObject_Slot8_Channel40_Index60_8883F6:
     STA.B $14                                                            ;888402;
     LDX.W #$0008                                                         ;888404;
     JMP.W SpawnHDMAObject_SlotX_Hardcoded                                ;888407;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 SpawnHDMAObject_SlotA_Channel80_Index70:
@@ -877,6 +879,7 @@ Instruction_HDMAObject_PreInstructionInY:
     RTS                                                                  ;888583;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_HDMAObject_ClearPreInstruction_888584:
     LDA.W #.return                                                       ;888584;
     STA.W $18F0,X                                                        ;888587;
@@ -920,6 +923,7 @@ UNUSED_Instruction_HDMAObject_CallFunctionYWithA_88859D:
     INY                                                                  ;8885B1;
     INY                                                                  ;8885B2;
     RTS                                                                  ;8885B3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_HDMAObject_CallExternalFunctionInY:
@@ -942,6 +946,7 @@ Instruction_HDMAObject_CallExternalFunctionInY:
     JML.W [$0012]                                                        ;8885CA;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_HDMAObject_CallExternalFuncYWithA_8885CD:
     LDA.W $0000,Y                                                        ;8885CD;
     STA.B $12                                                            ;8885D0;
@@ -962,6 +967,7 @@ UNUSED_Instruction_HDMAObject_CallExternalFuncYWithA_8885CD:
 
 .externalFunction:
     JML.W [$0012]                                                        ;8885E9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_HDMAObject_GotoY:
@@ -970,6 +976,7 @@ Instruction_HDMAObject_GotoY:
     RTS                                                                  ;8885F0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_HDMAObject_GotoY_Y_8885F1:
     STY.B $12                                                            ;8885F1;
     DEY                                                                  ;8885F3;
@@ -1045,6 +1052,7 @@ UNUSED_Instruction_HDMAObject_HDMATablePointerInY_88864C:
     INY                                                                  ;888652;
     INY                                                                  ;888653;
     RTS                                                                  ;888654;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_HDMAObject_HDMATableBank:
@@ -1075,10 +1083,12 @@ Instruction_HDMAObject_IndirectHDMATableBank:
     RTS                                                                  ;88867E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_HDMAObject_SkipNextInstruction_88867F:
     INY                                                                  ;88867F;
     INY                                                                  ;888680;
     RTS                                                                  ;888681;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_HDMAObject_Sleep:
@@ -2405,6 +2415,7 @@ Calculate_PowerBombPreExplosion_HDMAObjectTablePointers:
     RTL                                                                  ;888FB9;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CalcPowerBombRelatedHDMATables_Scaled_Left_888FBA:
     LDA.W PowerBomb_ShapeDefinitionTiles_Optimization_A226,Y             ;888FBA;
     STA.W $4203                                                          ;888FBD;
@@ -2529,6 +2540,7 @@ UNUSED_CalPBRelatedHDMADataTables_Scaled_OnScreen_88903A:
     INY                                                                  ;889075;
     BPL UNUSED_CalPBRelatedHDMADataTables_Scaled_OnScreen_88903A         ;889076;
     RTS                                                                  ;889078;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 PowerBomb_PreExplosion_Colors_red:
@@ -2542,6 +2554,7 @@ PowerBomb_PreExplosion_Colors_blue:
     db $0E,$0E,$0A,$10,$10,$08,$12,$12,$08,$14,$14,$08,$16,$16,$08,$18   ;88908B;
     db $18,$08,$1A,$1A,$0A,$18,$18,$08,$16,$16,$06,$14,$14,$04           ;88909B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PowerBomb_ExplosionRelated_Colors_8890A9:
     db $13,$13,$0F,$11,$11,$0E,$0F,$0F,$0D,$0D,$0D,$0C,$0B,$0B,$0B,$0A   ;8890A9;
     db $0A,$0A,$09,$09,$09,$08,$08,$08,$07,$07,$07,$06,$06,$06,$05,$05   ;8890B9;
@@ -2549,6 +2562,7 @@ UNUSED_PowerBomb_ExplosionRelated_Colors_8890A9:
 
 UNUSED_PowerBombColors_8890D9:
     dw $0001                                                             ;8890D9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PowerBomb_PreExplosion_InitialRadiusSpeed:
     dw $3000                                                             ;8890DB;
@@ -3189,6 +3203,7 @@ PreInstruction_CrystalFlash_2_AfterGlow:
     RTL                                                                  ;88A3B6;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CalcCrystalFlashHDMADataTables_PreScaled_Left_88A3B7:
     LDA.W $0CE6                                                          ;88A3B7;
     CLC                                                                  ;88A3BA;
@@ -3260,6 +3275,7 @@ UNUSED_Calc_CF_HDMADataTables_PreScaled_RightOfScreen_88A407:
     CPX.W #$00C0                                                         ;88A429;
     BNE UNUSED_Calc_CF_HDMADataTables_PreScaled_RightOfScreen_88A407     ;88A42C;
     RTS                                                                  ;88A42E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Calculate_CrystalFlash_HDMAObjectTablePointers:
@@ -3958,8 +3974,10 @@ Damage_Samus_IfSheIsInTheTopRow:
     RTS                                                                  ;88A8D9;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Table_88A8DA:
     dw $0000,$0010,$0020,$0020,$0010,$0030,$0040                         ;88A8DA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 FXType_22_RepeatingBG3StripsTable:
     dw $0000,$0010,$0020,$0030,$0010,$0030,$0040,$0010                   ;88A8E8;
@@ -4540,6 +4558,7 @@ PreInstruction_Fireflea_BG3XScroll:
     RTL                                                                  ;88B11D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spawn_ExpandingContractingEffect_HDMAObject_88B11E:
     PHP                                                                  ;88B11E;
     REP #$30                                                             ;88B11F;
@@ -4568,6 +4587,7 @@ UNUSED_Spawn_ExpandingContractingEffect_HDMAObject_88B11E:
     dw InstList_ExpandingContractingEffect_BG2YScroll_0                  ;88B168;
     PLP                                                                  ;88B16A;
     RTL                                                                  ;88B16B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_ExpandingContractingEffect_BG2YScroll_0:
@@ -5017,11 +5037,13 @@ PreInstruction_LavaAcid_BG3YScroll:
     RTL                                                                  ;88B48D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_WaveDisplacementTable_88B48E:
     dw $0000,$0001,$0001,$0000,$0000,$FFFF,$FFFF,$0000                   ;88B48E;
     dw $0000,$0001,$0001,$0000,$0000,$FFFF,$FFFF,$0000                   ;88B49E;
     dw $0000,$0001,$0001,$0000,$0000,$FFFF,$FFFF,$0000                   ;88B4AE;
     dw $0000,$0001,$0001,$0000,$0000,$FFFF,$FFFF,$0000                   ;88B4BE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_HDMAObject_PhaseDecreaseTimer_1:
     LDA.W #$0001                                                         ;88B4CE;
@@ -6489,6 +6511,7 @@ IndirectHDMATable_LavaAcid_BG3Yscroll:
     dw $9C02                                                             ;88BDAE;
     db $00                                                               ;88BDB0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_IndirectHDMATable_88BDB1:
     db $81                                                               ;88BDB1;
     dw $9C44                                                             ;88BDB2;
@@ -7002,6 +7025,7 @@ UNUSED_IndirectHDMATable_88BDB1:
     dw $9C44                                                             ;88C0AC;
     db $81                                                               ;88C0AE;
     dw $9C44                                                             ;88C0AF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 IndirectHDMATable_LavaAcidBG2_Yscroll:
     db $81                                                               ;88C0B1;
@@ -11248,12 +11272,14 @@ Instruction_HDMAObjectBG3XVelocity:
 .BG3XVelocities:
     dw $FA00,$0600,$FC00,$0400                                           ;88D992;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_IndirectHDMATable_88D99A:
     db $1F                                                               ;88D99A;
     dw $CAD8                                                             ;88D99B;
     db $81                                                               ;88D99D;
     dw $CADC                                                             ;88D99E;
     db $00                                                               ;88D9A0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PreInstruction_RainBG3Scroll:
     PHB                                                                  ;88D9A1;
@@ -11346,12 +11372,14 @@ InstList_Spores_BG3_Xscroll_1:
     dw Instruction_HDMAObject_GotoY                                      ;88DA3C;
     dw InstList_Spores_BG3_Xscroll_1                                     ;88DA3E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_IndirectHDMATable_88DA40:
     db $1F                                                               ;88DA40;
     dw $CAD8                                                             ;88DA41;
     db $81                                                               ;88DA43;
     dw $CADC                                                             ;88DA44;
     db $00                                                               ;88DA46;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PreInstruction_Spores_BG3_Xsscroll:
     PHB                                                                  ;88DA47;
@@ -11406,6 +11434,7 @@ PreInstruction_Spores_BG3_Xsscroll:
     RTL                                                                  ;88DA9E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HandleSporesWaviness_88DA9F:
     DEC.W $1920,X                                                        ;88DA9F;
     BNE .setupLoop                                                       ;88DAA2;
@@ -11451,6 +11480,7 @@ UNUSED_HandleSporesWaviness_88DA9F:
 .waveDisplacementTable:
     dw $0000,$0001,$0001,$0000,$0000,$FFFF,$FFFF,$0000                   ;88DAE8;
     dw $0000,$0001,$0001,$0000,$0000,$FFFF,$FFFF,$0000                   ;88DAF8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 FXType_C_Fog:
     SEP #$20                                                             ;88DB08;
@@ -11482,12 +11512,14 @@ RTS_88DB2E:
     RTS                                                                  ;88DB2E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_IndirectHDMATable_88DB2F:
     db $1F                                                               ;88DB2F;
     dw $CAD8                                                             ;88DB30;
     db $81                                                               ;88DB32;
     dw $CADC                                                             ;88DB33;
     db $00                                                               ;88DB35;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PreInstruction_Fog_BG3Scroll:
     PHB                                                                  ;88DB36;
@@ -11826,6 +11858,7 @@ FXType_2C_CeresHaze:
     RTL                                                                  ;88DDE1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Set_CeresHaze_PreInstruction_for_NoFade_88DDE2:
     LDA.W #UNUSED_PreInst_CeresHaze_ColorMathSubScnBackdropColor_NoFade  ;88DDE2;
     STA.W $18F0,X                                                        ;88DDE5;
@@ -11853,6 +11886,7 @@ UNUSED_PreInst_CeresHaze_ColorMathSubScnBackdropColor_NoFade:
     PLX                                                                  ;88DE0C;
     REP #$20                                                             ;88DE0D;
     RTL                                                                  ;88DE0F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 PreInst_CeresHaze_ColorMathSubScnBackdropColor_RidleyIsAlive:
@@ -12060,6 +12094,7 @@ Spawn_DraygonMainScreenLayers_HDMAObject:
     RTL                                                                  ;88DF3C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpawnHDMAObject_88DF3D:
     JSL.L Spawn_HDMAObject                                               ;88DF3D;
     db $00,$2C                                                           ;88DF41;
@@ -12072,6 +12107,7 @@ UNUSED_SpawnHDMAObject_88DF46:
     db $02,$12                                                           ;88DF4A;
     dw UNUSED_InstList_BG3_Yscroll_0_88DF77                              ;88DF4C;
     RTL                                                                  ;88DF4E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_DraygonMainScreenLayers_Initial:
@@ -12104,6 +12140,7 @@ InstList_DraygonMainScreenLayers_DraygonOffScreen:
     dw HDMATable_DraygonMainScreenLayers_DraygonOffScreen                ;88DF73;
     dw Instruction_HDMAObject_Sleep                                      ;88DF75;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_BG3_Yscroll_0_88DF77:
     dw Instruction_HDMAObject_HDMATableBank                              ;88DF77;
     db $88                                                               ;88DF79;
@@ -12120,6 +12157,7 @@ UNUSED_InstList_BG3_Yscroll_1_88DF87:
     dw Instruction_HDMAObject_GotoY                                      ;88DF8B;
     dw UNUSED_InstList_BG3_Yscroll_1_88DF87                              ;88DF8D;
     dw Instruction_HDMAObject_Sleep                                      ;88DF8F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RTL_88DF91:
     RTL                                                                  ;88DF91;
@@ -12207,12 +12245,14 @@ HDMATable_DraygonMainScreenLayers_DraygonAroundTop:
 HDMATable_DraygonMainScreenLayers_DraygonOffScreen:
     db $1F,$04,$81,$11,$00                                               ;88E01A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HDMATable_BG3_Yscroll:
     db $40                                                               ;88E01F;
     dw $0000                                                             ;88E020;
     db $81                                                               ;88E022;
     dw $0020                                                             ;88E023;
     db $00                                                               ;88E025;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PreInstruction_VariaSuitPickup:
     PHP                                                                  ;88E026;

--- a/src/bank_8B.asm
+++ b/src/bank_8B.asm
@@ -357,6 +357,7 @@ Setup_PPU_ZebesDestruction:
     RTS                                                                  ;8B8339;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Setup_PPU_ZebesDestructionSpaceView_8B833A:
     PHP                                                                  ;8B833A;
     SEP #$30                                                             ;8B833B;
@@ -423,6 +424,7 @@ UNUSED_Setup_PPU_ZebesDestructionSpaceView_8B833A:
     STZ.B $B7                                                            ;8B83CF;
     PLP                                                                  ;8B83D1;
     RTS                                                                  ;8B83D2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Setup_PPU_Credits:
@@ -506,6 +508,7 @@ Setup_PPU_Credits:
     RTS                                                                  ;8B8487;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ModifyMode7TransformAndBG1PosWithController_8B8488:
     PHP                                                                  ;8B8488;
     REP #$30                                                             ;8B8489;
@@ -591,6 +594,7 @@ UNUSED_ModifyMode7TransformAndBG1PosWithController_8B8488:
 .return:
     PLP                                                                  ;8B8516;
     RTS                                                                  ;8B8517;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 HandleMode7TransformMatrixAndBG1Position_NoRotation:
@@ -1218,6 +1222,7 @@ CinematicBGObjects_X_16_TilemapOffsetForTile_12_13:
     RTS                                                                  ;8B896A;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicBGObjects_IndirectInstructionFunction_8B896B:
     JSR.W UNUSED_CinematicBGObjects_Mode7TilemapOffsetForTile_8B8A2C     ;8B896B;
     LDA.W $0002,Y                                                        ;8B896E;
@@ -1337,6 +1342,7 @@ UNUSED_CinematicBGObjects_Mode7TilemapOffsetForTile_8B8A2C:
     ADC.W $0014                                                          ;8B8A4B;
     STA.W $0016                                                          ;8B8A4E;
     RTS                                                                  ;8B8A51;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Calculate_SamusPosition_InRotatingElevatorRoom:
@@ -1910,6 +1916,7 @@ DrawIntroSprites:
     RTS                                                                  ;8B8E51;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CalculateXYComponentsOfRadiusAAngleY_8B8E52:
     PHP                                                                  ;8B8E52;
     REP #$30                                                             ;8B8E53;
@@ -1991,6 +1998,7 @@ UNUSED_Math_8B8EA3:
     CLC                                                                  ;8B8ED5;
     ADC.B $12                                                            ;8B8ED6;
     RTS                                                                  ;8B8ED8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MoveUnusedSpritesOffScreen:
@@ -2668,6 +2676,7 @@ CinematicSpriteObject_Instruction_Delete:
     RTS                                                                  ;8B9441;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObject_Instruction_Sleep_8B9442:
     REP #$30                                                             ;8B9442;
     DEY                                                                  ;8B9444;
@@ -2676,6 +2685,7 @@ UNUSED_CinematicSpriteObject_Instruction_Sleep_8B9442:
     STA.W $1B1D,X                                                        ;8B9447;
     PLA                                                                  ;8B944A;
     RTS                                                                  ;8B944B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CinematicSpriteObject_Instruction_PreInstructionY:
@@ -2687,6 +2697,7 @@ CinematicSpriteObject_Instruction_PreInstructionY:
     RTS                                                                  ;8B9456;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObject_Inst_ClearPreInstruction_8B9457:
     REP #$30                                                             ;8B9457;
     LDA.W #.return                                                       ;8B9459;
@@ -2694,6 +2705,7 @@ UNUSED_CinematicSpriteObject_Inst_ClearPreInstruction_8B9457:
 
   .return
     RTS                                                                  ;8B945F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CinematicSpriteObject_Inst_CallExternalFunctionY_8B9460:
@@ -2738,6 +2750,7 @@ CinematicSpriteObject_Inst_CallExternalFunctionYWithA_8B947E:
     JML.W [$0012]                                                        ;8B949F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObject_Inst_GotoY_8B94A2:
     REP #$30                                                             ;8B94A2;
     STY.W $0012                                                          ;8B94A4;
@@ -2756,6 +2769,7 @@ UNUSED_CinematicSpriteObject_Inst_GotoY_8B94A2:
     ADC.W $0012                                                          ;8B94B7;
     TAY                                                                  ;8B94BA;
     RTS                                                                  ;8B94BB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CinematicSpriteObject_Instruction_GotoY:
@@ -2774,12 +2788,14 @@ CinematicSpriteObject_Inst_DecrementTimer_GotoYIfNonZero:
     RTS                                                                  ;8B94CC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObject_Inst_DecTimer_GotoY_8B94CD:
     REP #$30                                                             ;8B94CD;
     DEC.W $1B7D,X                                                        ;8B94CF;
     BNE UNUSED_CinematicSpriteObject_Inst_GotoY_8B94A2                   ;8B94D2;
     INY                                                                  ;8B94D4;
     RTS                                                                  ;8B94D5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CinematicSpriteObject_Instruction_TimerInY:
@@ -2791,9 +2807,11 @@ CinematicSpriteObject_Instruction_TimerInY:
     RTS                                                                  ;8B94E0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30RTS_8B94E1:
     REP #$30                                                             ;8B94E1;
     RTS                                                                  ;8B94E3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Spawn_Mode7Objects:
@@ -2894,6 +2912,7 @@ Mode7Objects_Instruction_Delete:
     RTS                                                                  ;8B9571;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Mode7Objects_Instruction_PreInstructionY_8B9572:
     REP #$30                                                             ;8B9572;
     LDA.W $0000,Y                                                        ;8B9574;
@@ -2910,6 +2929,7 @@ UNUSED_Mode7Objects_Instruction_ClearPreInstruction_8B957D:
 
   .return
     RTS                                                                  ;8B9585;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Mode7Objects_Instruction_GotoY:
@@ -3114,6 +3134,7 @@ CinematicBGObject_Instruction_Delete:
     RTS                                                                  ;8B96A2;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicBGObject_Instruction_Sleep_8B96A3:
     REP #$30                                                             ;8B96A3;
     DEY                                                                  ;8B96A5;
@@ -3203,6 +3224,7 @@ UNUSED_CinematicBGObjects_Inst_GotoY_8B9704:
     ADC.W $0012                                                          ;8B9719;
     TAY                                                                  ;8B971C;
     RTS                                                                  ;8B971D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CinematicBGObject_Instruction_GotoY:
@@ -3212,6 +3234,7 @@ CinematicBGObject_Instruction_GotoY:
     RTS                                                                  ;8B9724;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicBGObjects_Inst_DecrementTimer_GotoY_8B9724:
     REP #$30                                                             ;8B9725;
     DEC.W $19E5,X                                                        ;8B9727;
@@ -3241,6 +3264,7 @@ UNUSED_CinematicBGObjects_Inst_TimerInY_8B9738:
 UNUSED_REP30RTS_8B9743:
     REP #$30                                                             ;8B9743;
     RTS                                                                  ;8B9745;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Draw_CinematicSpriteObjects_IntroTitleSequence:
@@ -3819,6 +3843,7 @@ InitFunction_CinematicSpriteObject_SuperMetroidLogoImmediate:
     RTS                                                                  ;8B9B2C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 InitFunction_CinematicSpriteObject_UnusedNintendoBootLogoImm:
     LDA.W #$0080                                                         ;8B9B2D;
     STA.W $1A7D,Y                                                        ;8B9B30;
@@ -3827,6 +3852,7 @@ InitFunction_CinematicSpriteObject_UnusedNintendoBootLogoImm:
     LDA.W #$0000                                                         ;8B9B39;
     STA.W $1ABD,Y                                                        ;8B9B3C;
     RTS                                                                  ;8B9B3F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InitFunc_CinematicSpriteObject_NintendoCopyrightImmediate:
@@ -4010,9 +4036,11 @@ PreInstruction_CinematicSpriteObject_1994ScrollingText:
     RTS                                                                  ;8B9CDD;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP20RTS_8B9CDE:
     REP #$20                                                             ;8B9CDE;
     RTS                                                                  ;8B9CE0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_TriggerTitleSequenceScene0:
@@ -4257,6 +4285,7 @@ Instruction_FadeInNintendoCopyright:
     RTS                                                                  ;8B9ED5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 InitFunc_CinematicSpriteObject_UnusedNintendoBootLogo_FadeIn:
     LDA.W #$0080                                                         ;8B9ED6;
     STA.W $1A7D,Y                                                        ;8B9ED9;
@@ -4267,6 +4296,7 @@ InitFunc_CinematicSpriteObject_UnusedNintendoBootLogo_FadeIn:
     LDY.W #PaletteFXObjects_FadeInNintendoBootLogoForUnusedCode          ;8B9EE8;
     JSL.L Spawn_PaletteFXObject                                          ;8B9EEB;
     RTS                                                                  ;8B9EEF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_UsePalette0_FadeInNintendoCopyright:
@@ -4560,6 +4590,7 @@ InstList_CinematicSpriteObject_SuperMetroidTitleLogo_Immedia:
     dw CinematicSpriteObject_Instruction_GotoY                           ;8BA0CF;
     dw InstList_CinematicSpriteObject_SuperMetroidTitleLogo_Immedia      ;8BA0D1;
 
+if !FEATURE_KEEP_UNREFERENCED
 InstList_CinematicSpriteObject_UnusedNintendoBootLogo_FadeIn:
     dw $0020                                                             ;8BA0D3;
     dw TitleSequenceSpritemaps_NintendoBootLogo                          ;8BA0D5;
@@ -4570,6 +4601,7 @@ InstList_CinematicSpriteObject_UnusedNintendoBootLogo_Immedi:
     dw TitleSequenceSpritemaps_NintendoBootLogo                          ;8BA0DB;
     dw CinematicSpriteObject_Instruction_GotoY                           ;8BA0DD;
     dw InstList_CinematicSpriteObject_UnusedNintendoBootLogo_Immedi      ;8BA0DF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_CinematicSpriteObject_NintendoCopyright_FadeIn:
     dw $0020                                                             ;8BA0E1;
@@ -4603,10 +4635,12 @@ CinematicSpriteObjectDefinitions_TitleSequence:
     dw InitFunc_CinematicSpriteObject_SuperMetroidTitleLogo_FadeIn       ;8BA107;
     dw RTS_8B93D9                                                        ;8BA109;
     dw InstList_CinematicSpriteObject_SuperMetroidTitleLogo_FadeIn       ;8BA10B;
+if !FEATURE_KEEP_UNREFERENCED
   .UnusedNintendoBootLogo_FadeIn
     dw InitFunc_CinematicSpriteObject_UnusedNintendoBootLogo_FadeIn      ;8BA10D;
     dw RTS_8B93D9                                                        ;8BA10F;
     dw InstList_CinematicSpriteObject_UnusedNintendoBootLogo_FadeIn      ;8BA111;
+endif ; !FEATURE_KEEP_UNREFERENCED
   .NintendoCopyright_FadeIn
     dw InitFunc_CinematicSpriteObject_NintendoCopyright_FadeIn           ;8BA113;
     dw RTS_8B93D9                                                        ;8BA115;
@@ -4615,10 +4649,12 @@ CinematicSpriteObjectDefinitions_TitleSequence:
     dw InitFunction_CinematicSpriteObject_SuperMetroidLogoImmediate      ;8BA119;
     dw RTS_8B93D9                                                        ;8BA11B;
     dw InstList_CinematicSpriteObject_SuperMetroidTitleLogo_Immedia      ;8BA11D;
+if !FEATURE_KEEP_UNREFERENCED
   .UnusedNintendoBootLogoImm
     dw InitFunction_CinematicSpriteObject_UnusedNintendoBootLogoImm      ;8BA11F;
     dw RTS_8B93D9                                                        ;8BA121;
     dw InstList_CinematicSpriteObject_UnusedNintendoBootLogo_Immedi      ;8BA123;
+endif ; !FEATURE_KEEP_UNREFERENCED
   .NintendoCopyrightImmediate
     dw InitFunc_CinematicSpriteObject_NintendoCopyrightImmediate         ;8BA125;
     dw RTS_8B93D9                                                        ;8BA127;
@@ -6735,6 +6771,7 @@ PreInstruction_CinematicBGObject_SamusBlinking:
     RTS                                                                  ;8BB4DB;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicBGObject_8BB4DC:
     LDA.W $1B3B                                                          ;8BB4DC;
     CMP.W #InstList_IntroTextCaret_Blink                                 ;8BB4DF;
@@ -6762,6 +6799,7 @@ UNUSED_Instruction_LoadIntroJapanText_NonExistent:
     JSR.W TransferJapanTextTilesToVRAM                                   ;8BB514;
     PLY                                                                  ;8BB517;
     RTS                                                                  ;8BB518;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EnableCinematicBGTilemapUpdates:
@@ -8185,6 +8223,7 @@ CinematicFunction_FlyToCeres_FlyingIntoCeres:
     RTS                                                                  ;8BC082;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitFunc_CinematicSpriteObject_SpaceColonyText_8BC083:
     LDA.W #$007C                                                         ;8BC083;
     STA.W $1A7D,Y                                                        ;8BC086;
@@ -8193,6 +8232,7 @@ UNUSED_InitFunc_CinematicSpriteObject_SpaceColonyText_8BC083:
     LDA.W #$0000                                                         ;8BC08F;
     STA.W $1ABD,Y                                                        ;8BC092;
     RTS                                                                  ;8BC095;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_SkipNextInstructionIfEnglishText:
@@ -8216,6 +8256,7 @@ Instruction_FinishFlyToCeres:
     RTS                                                                  ;8BC0B1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitFunc_CineSpriteObject_SpaceColonyJapanText_8BC0B2:
     LDA.W #$007C                                                         ;8BC0B2;
     STA.W $1A7D,Y                                                        ;8BC0B5;
@@ -8224,6 +8265,7 @@ UNUSED_InitFunc_CineSpriteObject_SpaceColonyJapanText_8BC0B2:
     LDA.W #$0000                                                         ;8BC0BE;
     STA.W $1ABD,Y                                                        ;8BC0C1;
     RTS                                                                  ;8BC0C4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CinematicFunction_FlyToCeres_Finish:
@@ -9153,6 +9195,7 @@ PreInstruction_Zebes_SlideSceneAway:
     RTS                                                                  ;8BC896;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InitFunction_CinematicSpriteObject_ZebesStars1_8BC897:
     LDA.W #$0080                                                         ;8BC897;
     STA.W $1A7D,Y                                                        ;8BC89A;
@@ -9161,6 +9204,7 @@ UNUSED_InitFunction_CinematicSpriteObject_ZebesStars1_8BC897:
     LDA.W #$0800                                                         ;8BC8A3;
     STA.W $1ABD,Y                                                        ;8BC8A6;
     RTS                                                                  ;8BC8A9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 PreInstruction_CinematicSpriteObject_ZebesStars5:
@@ -9719,6 +9763,7 @@ InstList_CinematicSpriteObject_CeresPurpleSpaceVortext:
     dw CinematicSpriteObject_Instruction_GotoY                           ;8BCC5F;
     dw InstList_CinematicSpriteObject_CeresPurpleSpaceVortext            ;8BCC61;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_CinematicSpriteObject_SpaceColonyText_8BCC63:
     dw $0100,$0000,$000A                                                 ;8BCC63;
     dw UNUSED_SpaceSpritemaps_S_8C92AA                                   ;8BCC69;
@@ -9758,6 +9803,7 @@ UNUSED_InstList_CineSpriteObject_SpaceColonyJapanText_8BCCA3:
     dw UNUSED_SpaceSpritemaps_JapanText_SPACECOLONY_8C9258               ;8BCCA5;
     dw CinematicSpriteObject_Instruction_GotoY                           ;8BCCA7;
     dw UNUSED_InstList_CineSpriteObject_SpaceColonyJapanText_8BCCA3      ;8BCCA9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_CinematicSpriteObject_Zebes:
     dw $000A                                                             ;8BCCAB;
@@ -9765,11 +9811,13 @@ InstList_CinematicSpriteObject_Zebes:
     dw CinematicSpriteObject_Instruction_GotoY                           ;8BCCAF;
     dw InstList_CinematicSpriteObject_Zebes                              ;8BCCB1;
 
+if !FEATURE_KEEP_UNREFERENCED
 InstList_CinematicSpriteObject_ZebesStars1:
     dw $000A                                                             ;8BCCB3;
     dw UNUSED_SpaceSpritemaps_ZebesStars1_8C96CB                         ;8BCCB5;
     dw CinematicSpriteObject_Instruction_GotoY                           ;8BCCB7;
     dw InstList_CinematicSpriteObject_ZebesStars1                        ;8BCCB9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_CinematicSpriteObject_PlanetZebesText:
     dw $0040,$0000                                                       ;8BCCBB;
@@ -10080,6 +10128,7 @@ CinematicSpriteObjectDefinitions_CeresPurpleSpaceVortex:
     dw PreInstruction_CinematicSpriteObject_CeresPurpleSpaceVortex       ;8BCE93;
     dw InstList_CinematicSpriteObject_CeresPurpleSpaceVortext            ;8BCE95;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObjectDefs_SpaceColonyText_8BCE97:
     dw UNUSED_InitFunc_CinematicSpriteObject_SpaceColonyText_8BC083      ;8BCE97;
     dw RTS_8B93D9                                                        ;8BCE99;
@@ -10089,16 +10138,19 @@ UNUSED_CinematicSpriteObjectDefs_SpaceColonyJapanText_8BCE9D:
     dw UNUSED_InitFunc_CineSpriteObject_SpaceColonyJapanText_8BC0B2      ;8BCE9D;
     dw RTS_8B93D9                                                        ;8BCE9F;
     dw UNUSED_InstList_CineSpriteObject_SpaceColonyJapanText_8BCCA3      ;8BCEA1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 CinematicSpriteObjectDefinitions_Zebes:
     dw InitFunction_CinematicSpriteObject_Zebes                          ;8BCEA3;
     dw PreInstruction_CinematicSpriteObject_Zebes                        ;8BCEA5;
     dw InstList_CinematicSpriteObject_Zebes                              ;8BCEA7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObjectDefinitions_ZebesStars1_8BCEA9:
     dw UNUSED_InitFunction_CinematicSpriteObject_ZebesStars1_8BC897      ;8BCEA9;
     dw PreInstruction_CinematicSpriteObject_ZebesStars5                  ;8BCEAB;
     dw InstList_CinematicSpriteObject_ZebesStars1                        ;8BCEAD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 CinematicSpriteObjectDefinitions_PlanetZebesText:
     dw InitFunction_CinematicSpriteObject_PlanetZebesText                ;8BCEAF;
@@ -10260,10 +10312,12 @@ CinematicSpriteObjectDefinitions_SpaceColony:
     dw RTS_8B93D9                                                        ;8BCF6B;
     dw CinematicBGObjectInstLists_SpaceColony                            ;8BCF6D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CinematicSpriteObjectDefs_IntroTextPage1_8BCF6F:
     dw RTS_8B93D9                                                        ;8BCF6F;
     dw RTS_8B93D9                                                        ;8BCF71;
     dw CinematicBGObjectInstLists_IntroTextPage1                         ;8BCF73;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 IntroJapanTextData_Page1_TopLine:
     dw $0040,$0011,$0A60,$0B60,$04E0,$0150,$0EF0,$0EF0                   ;8BCF75;
@@ -10448,12 +10502,14 @@ InstList_Mode7Object_Page6:
     dw Instruction_EnableCinematicBGTilemapUpdates_duplicate_again       ;8BD3F1;
     dw Mode7Objects_Instruction_Delete                                   ;8BD3F3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Mode7Object_D43D_8BD3F5:
     dw UNUSED_Instruction_LoadIntroJapanText_NonExistent                 ;8BD3F5;
     dw $0001                                                             ;8BD3F7;
     dw Mode7_Transfer_Data                                               ;8BD3F9;
     dw Instruction_EnableCinematicBGTilemapUpdates                       ;8BD3FB;
     dw Mode7Objects_Instruction_Delete                                   ;8BD3FD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Mode7_Transfer_Data:
     db $00,$00                                                           ;8BD3FF;
@@ -10508,10 +10564,12 @@ Mode7Objects_IntroJapanText_Page6:
     dw RTS_8B93D9                                                        ;8BD439;
     dw InstList_Mode7Object_Page6                                        ;8BD43B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Mode7Objects_8BD43D:
     dw RTS_8B93D9                                                        ;8BD43D;
     dw RTS_8B93D9                                                        ;8BD43F;
     dw UNUSED_InstList_Mode7Object_D43D_8BD3F5                           ;8BD441;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 GameState27_EndingAndCredits:
     PHP                                                                  ;8BD443;

--- a/src/bank_8C.asm
+++ b/src/bank_8C.asm
@@ -2,6 +2,7 @@
 org $8C8000
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TitleSequenceSpritemaps_BetaMetroidLogo_8C8000:
     dw $0025,$0050                                                       ;8C8000;
     db $E8                                                               ;8C8004;
@@ -78,6 +79,7 @@ UNUSED_TitleSequenceSpritemaps_BetaMetroidLogo_8C8000:
     dw $3122,$C3A0                                                       ;8C80B4;
     db $F8                                                               ;8C80B8;
     dw $3120                                                             ;8C80B9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 TitleSequenceSpritemaps_NintendoBootLogo:
     dw $000E,$C230                                                       ;8C80BB;
@@ -133,6 +135,7 @@ TitleSequenceSpritemaps_NintendoCopyright:
     db $FC                                                               ;8C8134;
     dw $31C1                                                             ;8C8135;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TitleSequenceSpritemaps_1993RandD1Produce_8C8137:
     dw $001E,$01D4                                                       ;8C8137;
     db $00                                                               ;8C813B;
@@ -626,6 +629,7 @@ UNUSED_TitleSequenceSpritemaps_4x4TileRegion_8C8576:
     dw $34A1,$01F0                                                       ;8C85C1;
     db $F0                                                               ;8C85C5;
     dw $34A0                                                             ;8C85C6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 TitleSequenceSpritemaps_METR:
     dw $0008,$001C                                                       ;8C85C8;
@@ -669,6 +673,7 @@ TitleSequenceSpritemaps_METRO:
     db $F8                                                               ;8C8623;
     dw $338A                                                             ;8C8624;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TitleSequenceSpritemaps_DebugNintendoCopyright:
     dw $0011,$0003                                                       ;8C8626;
     db $08                                                               ;8C862A;
@@ -705,6 +710,7 @@ UNUSED_TitleSequenceSpritemaps_DebugNintendoCopyright:
     dw $31C2,$01D8                                                       ;8C8676;
     db $FC                                                               ;8C867A;
     dw $31C1                                                             ;8C867B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 TitleSequenceSpritemaps_METROI:
     dw $000C,$001C                                                       ;8C867D;
@@ -2071,6 +2077,7 @@ SpaceSpritemaps_CeresUnderAttack:
     db $D0                                                               ;8C921C;
     dw $0CE6                                                             ;8C921D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpaceSpritemaps_SPACECOLONY_8C921F:
     dw $000B,$0028                                                       ;8C921F;
     db $FC                                                               ;8C9223;
@@ -2270,6 +2277,7 @@ UNUSED_SpaceSpritemaps_SPACECOLON_8C939D:
     dw $31EE,$01D0                                                       ;8C93CA;
     db $FC                                                               ;8C93CE;
     dw $31ED                                                             ;8C93CF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SpaceSpritemaps_CeresPurpleVortexFrame2:
     dw $0021,$0010                                                       ;8C93D1;
@@ -2589,6 +2597,7 @@ SpaceSpritemaps_JapanText_PlanetZebes:
     db $F8                                                               ;8C96C8;
     dw $009F                                                             ;8C96C9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpaceSpritemaps_ZebesStars1_8C96CB:
     dw $001D,$01F0                                                       ;8C96CB;
     db $38                                                               ;8C96CF;
@@ -2649,6 +2658,7 @@ UNUSED_SpaceSpritemaps_ZebesStars1_8C96CB:
     dw $0809,$0190                                                       ;8C9757;
     db $88                                                               ;8C975B;
     dw $0800                                                             ;8C975C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SpaceSpritemaps_ZebesStars2:
     dw $000C,$0038                                                       ;8C975E;

--- a/src/bank_8D.asm
+++ b/src/bank_8D.asm
@@ -77,6 +77,7 @@ EnemyProjSpritemaps_CrocomiresProjectile_3:
     db $F8                                                               ;8D807F;
     dw $30D3                                                             ;8D8080;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_OldCrocomiresProjectile_0_8D8082:
     dw $0004,$0000                                                       ;8D8082;
     db $00                                                               ;8D8086;
@@ -118,6 +119,7 @@ UNUSED_EnemyProjSpritemaps_3_8D80C3:
     dw $0001,$01F8                                                       ;8D80C3;
     db $F8                                                               ;8D80C7;
     dw $317B                                                             ;8D80C8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_RidleysFireball_0:
     dw $0001,$C3F8                                                       ;8D80CA;
@@ -176,6 +178,7 @@ EnemyProjSpritemaps_CrocomiresSpikeWallPieces:
     db $F8                                                               ;8D8119;
     dw $65CC                                                             ;8D811A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8D811C:
     dw $0004,$0000                                                       ;8D811C;
     db $00                                                               ;8D8120;
@@ -235,6 +238,7 @@ UNUSED_EnemyProjSpritemaps_CrocomireBridgeCrumbling_2_8D815E:
     dw $21CE,$01F0                                                       ;8D8195;
     db $F8                                                               ;8D8199;
     dw $21CD                                                             ;8D819A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_PhantoonFlames_0:
     dw $0002,$C3F8                                                       ;8D819C;
@@ -482,6 +486,7 @@ EnemyProjSpritemaps_MotherBrainsBomb_8:
     db $FC                                                               ;8D8345;
     dw $75AF                                                             ;8D8346;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8D8348:
     dw $0001,$01FC                                                       ;8D8348;
     db $FC                                                               ;8D834C;
@@ -496,6 +501,7 @@ UNUSED_EnemyProjSpritemaps_2_8D8356:
     dw $0001,$01FC                                                       ;8D8356;
     db $FC                                                               ;8D835A;
     dw $35E2                                                             ;8D835B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_MotherBrainsRedBeam_0:
     dw $0001,$01FC                                                       ;8D835D;
@@ -628,6 +634,7 @@ EnemyProjSpritemaps_MetareeParticle:
     db $FC                                                               ;8D8439;
     dw $312B                                                             ;8D843A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8D343C:
     dw $0001,$C3F8                                                       ;8D843C;
     db $F8                                                               ;8D8440;
@@ -647,6 +654,7 @@ UNUSED_EnemyProjSpritemaps_3_8D3451:
     dw $0001,$C3F8                                                       ;8D8451;
     db $F2                                                               ;8D8455;
     dw $3A9C                                                             ;8D8456;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_KagoBugs_0:
     dw $0001,$01FC                                                       ;8D8458;
@@ -1276,6 +1284,7 @@ EnemyProjSpritemaps_GunshipLiftoffDustClouds_2D:
     db $DC                                                               ;8D8964;
     dw $7BC0                                                             ;8D8965;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_Draygon_0_8D8967:
     dw $0001,$01FC                                                       ;8D8967;
     db $FC                                                               ;8D896B;
@@ -1400,6 +1409,7 @@ UNUSED_EnemyProjSpritemaps_Draygon_8D8A0F:
     dw $0001,$81F8                                                       ;8D8A0F;
     db $F8                                                               ;8D8A13;
     dw $2164                                                             ;8D8A14;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_DraygonGoop_0:
     dw $0001,$81F8                                                       ;8D8A16;
@@ -1421,6 +1431,7 @@ EnemyProjSpritemaps_DraygonGoop_3:
     db $F8                                                               ;8D8A2F;
     dw $114A                                                             ;8D8A30;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_Draygon_0_8D8A32:
     dw $0001,$01FC                                                       ;8D8A32;
     db $FC                                                               ;8D8A36;
@@ -1465,6 +1476,7 @@ UNUSED_EnemyProjSpritemaps_1_8D8A6A:
     dw $0001,$81F8                                                       ;8D8A6A;
     db $F8                                                               ;8D8A6E;
     dw $218E                                                             ;8D8A6F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_DraygonsWallTurretProjectile_0:
     dw $0001,$01FC                                                       ;8D8A71;
@@ -1740,10 +1752,12 @@ EnemyProjSpritemaps_Pirate_MotherBrain_Laser_A:
     db $F8                                                               ;8D8C4A;
     dw $3A60                                                             ;8D8C4B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_QuestionMark_8D8C4D:
     dw $0001,$C3F8                                                       ;8D8C4D;
     db $F8                                                               ;8D8C51;
     dw $2AE0                                                             ;8D8C52;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_EnemyProjSpritemaps_BombTorizoLowHealthDrool_0_8D8C54:
     dw $0001,$01FC                                                       ;8D8C54;
@@ -1913,10 +1927,12 @@ EnemyProjSpritemaps_TorizoSonicBoom_5:
     db $E8                                                               ;8D8D92;
     dw $6B49                                                             ;8D8D93;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8D8D95:
     dw $0001,$01FC                                                       ;8D8D95;
     db $FC                                                               ;8D8D99;
     dw $2A5E                                                             ;8D8D9A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Common_0:
     dw $0001,$01FC                                                       ;8D8D9C;
@@ -2383,10 +2399,12 @@ EnemyProjSpritemaps_EyeDoorSweat_3:
     db $FC                                                               ;8D907C;
     dw $2A2E                                                             ;8D907D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8D907F:
     dw $0001,$01FC                                                       ;8D907F;
     db $FC                                                               ;8D9083;
     dw $2A2F                                                             ;8D9084;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_TourianStatueUnlockParticleWaterSplash_0:
     dw $0001,$01FC                                                       ;8D9086;
@@ -2638,6 +2656,7 @@ EnemyProjSpritemaps_TourianStatuePhantoon:
     db $DC                                                               ;8D9265;
     dw $2549                                                             ;8D9266;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8D9268:
     dw $0001,$81F9                                                       ;8D9268;
     db $F9                                                               ;8D926C;
@@ -2742,6 +2761,7 @@ UNUSED_EnemyProjSpritemaps_12_8D92FA:
     dw $632A,$8009                                                       ;8D92FF;
     db $F0                                                               ;8D9303;
     dw $232A                                                             ;8D9304;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_PuromiBody_0:
     dw $0001,$81F9                                                       ;8D9306;
@@ -2783,8 +2803,10 @@ EnemyProjSpritemaps_PuromiBody_7:
     db $F8                                                               ;8D933B;
     dw $E322                                                             ;8D933C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8D933E:
     dw $0000                                                             ;8D933E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_LavaquakeRocks:
     dw $0001,$01FC                                                       ;8D9340;
@@ -3284,6 +3306,7 @@ EnemyProjSpritemaps_MotherBrainExplodedEscapeDoorParticles_7:
     db $F8                                                               ;8D96D0;
     dw $330A                                                             ;8D96D1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8D96D3:
     dw $0001,$01FC                                                       ;8D96D3;
     db $FC                                                               ;8D96D7;
@@ -3323,6 +3346,7 @@ UNUSED_EnemyProjSpritemaps_7_8D9704:
     dw $0001,$01FC                                                       ;8D9704;
     db $FC                                                               ;8D9708;
     dw $331F                                                             ;8D9709;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_TimeBombSetJapanSet:
     dw $000C,$0008                                                       ;8D970B;
@@ -4275,6 +4299,7 @@ EnemyProjSpritemaps_NoobTubeCrack_5:
     db $D0                                                               ;8D9E26;
     dw $3300                                                             ;8D9E27;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8D9E29:
     dw $000E,$C200                                                       ;8D9E29;
     db $EF                                                               ;8D9E2D;
@@ -4305,6 +4330,7 @@ UNUSED_EnemyProjSpritemaps_8D9E29:
     dw $3367,$C3D9                                                       ;8D9E6A;
     db $F9                                                               ;8D9E6E;
     dw $3365                                                             ;8D9E6F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_NoobTubeCrack_6:
     dw $000E,$C20C                                                       ;8D9E71;
@@ -5397,10 +5423,12 @@ EnemyProjSpritemaps_NoobTubeReleasedAirBubbles_3:
     db $10                                                               ;8DA7F2;
     dw $3A9C                                                             ;8DA7F3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_NoobTubeReleasedAirBubbles_8DA7F5:
     dw $C3F8                                                             ;8DA7F5;
     db $C0                                                               ;8DA7F7;
     dw $3A9C                                                             ;8DA7F8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_NoobTubeReleasedAirBubbles_4:
     dw $0007,$01FD                                                       ;8DA7FA;
@@ -5592,6 +5620,7 @@ UNUSED_EnemyProjSpritemaps_StokeProjectile_1_8DA955:
     db $FC                                                               ;8DA959;
     dw $311D                                                             ;8DA95A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DA95C:
     dw $0001,$C3F8                                                       ;8DA95C;
     db $F8                                                               ;8DA960;
@@ -5631,6 +5660,7 @@ UNUSED_EnemyProjSpritemaps_7_8DA98D:
     dw $0001,$01FC                                                       ;8DA98D;
     db $FC                                                               ;8DA991;
     dw $312E                                                             ;8DA992;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_SporeSpawnsStalk:
     dw $0001,$81F8                                                       ;8DA994;
@@ -5667,6 +5697,7 @@ EnemyProjSpritemaps_Spores_2:
     db $FC                                                               ;8DA9C2;
     dw $2F2E                                                             ;8DA9C3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DA9C5:
     dw $0018,$8000                                                       ;8DA9C5;
     db $26                                                               ;8DA9C9;
@@ -5768,6 +5799,7 @@ UNUSED_EnemyProjSpritemaps_1_8DA93F:
     dw $2102,$81D0                                                       ;8DAAB2;
     db $C8                                                               ;8DAAB6;
     dw $2100                                                             ;8DAAB7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Namihe_Fune_Fireball_0:
     dw $0001,$81F8                                                       ;8DAAB9;
@@ -5799,6 +5831,7 @@ EnemyProjSpritemaps_Namihe_Fune_Fireball_5:
     db $F8                                                               ;8DAAE0;
     dw $610E                                                             ;8DAAE1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DAAE3:
     dw $0004,$01F8                                                       ;8DAAE3;
     db $00                                                               ;8DAAE7;
@@ -5820,6 +5853,7 @@ UNUSED_EnemyProjSpritemaps_1_8DAAF9:
     dw $212D,$01F8                                                       ;8DAB08;
     db $F8                                                               ;8DAB0C;
     dw $212C                                                             ;8DAB0D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_MagdolliteFlame_0:
     dw $0004,$0000                                                       ;8DAB0F;
@@ -6621,6 +6655,7 @@ EnemyProjSpritemaps_DustCloud_Explosion_3D:
     db $F0                                                               ;8DB103;
     dw $3A74                                                             ;8DB104;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8DB106:
     dw $0004,$01F8                                                       ;8DB106;
     db $00                                                               ;8DB10A;
@@ -6631,6 +6666,7 @@ UNUSED_EnemyProjSpritemaps_8DB106:
     dw $3A5E,$01F8                                                       ;8DB115;
     db $F8                                                               ;8DB119;
     dw $3A5E                                                             ;8DB11A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_DustCloud_Explosion_3E:
     dw $0001,$01FC                                                       ;8DB11C;
@@ -6667,10 +6703,12 @@ EnemyProjSpritemaps_DustCloud_Explosion_44:
     db $FC                                                               ;8DB14A;
     dw $3A7B                                                             ;8DB14B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8DB14D:
     dw $0001,$01FC                                                       ;8DB14D;
     db $FC                                                               ;8DB151;
     dw $3A5F                                                             ;8DB152;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_DustCloud_Explosion_45:
     dw $0001,$01FC                                                       ;8DB154;
@@ -6748,6 +6786,7 @@ EnemyProjSpritemaps_CeresElevatorPad_DustCloud_Explosion_1:
     db $FC                                                               ;8DB1E3;
     dw $3A6D                                                             ;8DB1E4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8DB1E6:
     dw $0004,$01F0                                                       ;8DB1E6;
     db $FE                                                               ;8DB1EA;
@@ -6758,6 +6797,7 @@ UNUSED_EnemyProjSpritemaps_8DB1E6:
     dw $3A6F,$01F8                                                       ;8DB1F5;
     db $FE                                                               ;8DB1F9;
     dw $3A6F                                                             ;8DB1FA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_DustCloud_Explosion_4B:
     dw $0001,$81F8                                                       ;8DB1FC;
@@ -6839,6 +6879,7 @@ EnemyProjSpritemaps_Common_Smoke_3:
     db $F0                                                               ;8DB269;
     dw $3A9E                                                             ;8DB26A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DB26C:
     dw $0001,$01FC                                                       ;8DB26C;
     db $FC                                                               ;8DB270;
@@ -6848,6 +6889,7 @@ UNUSED_EnemyProjSpritemaps_1_8DB273:
     dw $0001,$01FC                                                       ;8DB273;
     db $FC                                                               ;8DB277;
     dw $3A43                                                             ;8DB278;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_MotherBrainsTurretBullets:
     dw $0001,$01FC                                                       ;8DB27A;
@@ -6932,6 +6974,7 @@ EnemyProjSpritemaps_DustCloud_Explosion_62:
     db $FC                                                               ;8DB2FF;
     dw $3A4F                                                             ;8DB300;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DB302:
     dw $0002,$01FF                                                       ;8DB302;
     db $FC                                                               ;8DB306;
@@ -7059,6 +7102,7 @@ UNUSED_EnemyProjSpritemaps_F_8DB3D9:
     dw $BA67,$01FA                                                       ;8DB3E3;
     db $02                                                               ;8DB3E7;
     dw $BA66                                                             ;8DB3E8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_DustCloud_Explosion_63:
     dw $0001,$01FC                                                       ;8DB3EA;
@@ -7075,10 +7119,12 @@ EnemyProjSpritemaps_DustCloud_Explosion_65:
     db $FC                                                               ;8DB3FC;
     dw $3A3E                                                             ;8DB3FD;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_8DB3FF:
     dw $0001,$01FC                                                       ;8DB3FF;
     db $FC                                                               ;8DB403;
     dw $3A3F                                                             ;8DB404;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Common_BigExplosion_0:
     dw $0004,$0000                                                       ;8DB406;
@@ -7418,6 +7464,7 @@ EnemyProjSpritemaps_BotwoonsBody_B:
     db $F8                                                               ;8DB67F;
     dw $2166                                                             ;8DB680;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemap_BotwoonsBody_DownFacingLeft_8DB682:
     dw $0001,$81F8                                                       ;8DB682;
     db $F8                                                               ;8DB686;
@@ -7437,6 +7484,7 @@ UNUSED_EnemyProjSpritemap_BotwoonsBody_DownFacingLeft_8DB697:
     dw $0001,$81F8                                                       ;8DB697;
     db $F8                                                               ;8DB69B;
     dw $216E                                                             ;8DB69C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_BotwoonsBody_C:
     dw $0001,$81F8                                                       ;8DB69E;
@@ -7578,6 +7626,7 @@ EnemyProjSpritemaps_BotwoonsBody_27:
     db $F8                                                               ;8DB75F;
     dw $61A2                                                             ;8DB760;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_BotwoonsBodyTail_0_8DB762:
     dw $0001,$81F8                                                       ;8DB762;
     db $F8                                                               ;8DB766;
@@ -7817,6 +7866,7 @@ UNUSED_EnemyProjSpritemaps_BotwoonsBodyTail_2F_8DB8AB:
     dw $0001,$81F8                                                       ;8DB8AB;
     db $F8                                                               ;8DB8AF;
     dw $41A2                                                             ;8DB8B0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_BotwoonsBody_28:
     dw $0000                                                             ;8DB8B2;
@@ -7856,6 +7906,7 @@ EnemyProjSpritemaps_YappingMawsBody_1:
     db $F8                                                               ;8DB8E2;
     dw $A10A                                                             ;8DB8E3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_EDeathExplo_KillContact_0_8DB8E5:
     dw $0003,$81F0                                                       ;8DB8E5;
     db $00                                                               ;8DB8E9;
@@ -8538,6 +8589,7 @@ UNUSED_EnemyProjSpritemaps_38_8DBDEE:
     dw $BA5D,$0000                                                       ;8DBDF8;
     db $02                                                               ;8DBDFC;
     dw $BA5D                                                             ;8DBDFD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_EnemyDeathExplosion_0:
     dw $0001,$01FC                                                       ;8DBDFF;
@@ -8599,6 +8651,7 @@ EnemyProjSpritemaps_EnemyDeathExplosion_5:
     db $F0                                                               ;8DBE71;
     dw $3A96                                                             ;8DBE72;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DBE74:
     dw $0004,$0000                                                       ;8DBE74;
     db $00                                                               ;8DBE78;
@@ -8684,6 +8737,7 @@ UNUSED_EnemyProjSpritemaps_9_8DBF0D:
     dw $0001,$01FC                                                       ;8DBF0D;
     db $FC                                                               ;8DBF11;
     dw $3C3B                                                             ;8DBF12;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_0:
     dw $0001,$01FC                                                       ;8DBF14;
@@ -8705,6 +8759,7 @@ EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_3:
     db $FC                                                               ;8DBF2D;
     dw $307B                                                             ;8DBF2E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DBF30:
     dw $0001,$01FC                                                       ;8DBF30;
     db $FC                                                               ;8DBF34;
@@ -8891,6 +8946,7 @@ UNUSED_EnemyProjSpritemaps_1C_8DC05D:
     dw $0001,$01FC                                                       ;8DC05D;
     db $FC                                                               ;8DC061;
     dw $3A40                                                             ;8DC062;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_4:
     dw $0001,$01FC                                                       ;8DC064;
@@ -8950,6 +9006,7 @@ EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_B:
     db $FC                                                               ;8DC0C6;
     dw $3A42                                                             ;8DC0C7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_Pickup_Bombs_0_8DC0C9:
     dw $0001,$01FC                                                       ;8DC0C9;
     db $FC                                                               ;8DC0CD;
@@ -8985,6 +9042,7 @@ UNUSED_EnemyProjSpritemaps_1_8DC0F1:
     dw $3A58,$01FA                                                       ;8DC0FB;
     db $FD                                                               ;8DC0FF;
     dw $3A57                                                             ;8DC100;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_C:
     dw $0002,$01FD                                                       ;8DC102;
@@ -9000,6 +9058,7 @@ EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_D:
     db $FF                                                               ;8DC117;
     dw $305A                                                             ;8DC118;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DC11A:
     dw $0003,$01FE                                                       ;8DC11A;
     db $F5                                                               ;8DC11E;
@@ -9056,6 +9115,7 @@ UNUSED_EnemyProjSpritemaps_6_8DC171:
     dw $3A67,$01FA                                                       ;8DC17B;
     db $F6                                                               ;8DC17F;
     dw $3A66                                                             ;8DC180;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_E:
     dw $0002,$01FC                                                       ;8DC182;
@@ -9071,6 +9131,7 @@ EnemyProjSpritemaps_Pickup_EnemyDeathExplosion_F:
     db $00                                                               ;8DC197;
     dw $306A                                                             ;8DC198;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyProjSpritemaps_0_8DC19A:
     dw $0003,$01F6                                                       ;8DC19A;
     db $FE                                                               ;8DC19E;
@@ -9237,6 +9298,7 @@ UNUSED_EnemyProjSpritemaps_E_8DC2AB:
     dw $7AB8,$C3E8                                                       ;8DC2E2;
     db $E8                                                               ;8DC2E6;
     dw $3AB8                                                             ;8DC2E7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyProjSpritemaps_EnemyDeathExplosion_6:
     dw $0004,$8000                                                       ;8DC2E9;
@@ -9685,6 +9747,7 @@ Instruction_PaletteFXObject_ColorIndex_Plus12:
     RTS                                                                  ;8DC5C5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PaletteFXObject_ColorIndex_Plus1E_8DC5C6:
     TXA                                                                  ;8DC5C6;
     CLC                                                                  ;8DC5C7;
@@ -9693,6 +9756,7 @@ UNUSED_Instruction_PaletteFXObject_ColorIndex_Plus1E_8DC5C6:
     INY                                                                  ;8DC5CC;
     INY                                                                  ;8DC5CD;
     RTS                                                                  ;8DC5CE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_Delete_8DC5CF:
@@ -9709,14 +9773,17 @@ Instruction_PaletteFXObject_PreInstructionInY:
     RTS                                                                  ;8DC5DC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_PaletteFXObject_ClearPreInstruction_8DC5DD:
     LDA.W #RTS_8DC5E3                                                    ;8DC5DD;
     STA.W $1EAD,X                                                        ;8DC5E0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RTS_8DC5E3:
     RTS                                                                  ;8DC5E3;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_PaletteFXObject_CallExternalFunctionInY_8DC5E4:
     LDA.W $0000,Y                                                        ;8DC5E4;
     STA.B $12                                                            ;8DC5E7;
@@ -9755,6 +9822,7 @@ UNUSED_Inst_PaletteFXObject_CallExternalFuncInYWithA_8DC5FE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;8DC61B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PaletteFXObject_GotoY:
@@ -9763,6 +9831,7 @@ Instruction_PaletteFXObject_GotoY:
     RTS                                                                  ;8DC622;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PaletteFXObject_GotoYPlusY_8DC623:
     STY.B $12                                                            ;8DC623;
     DEY                                                                  ;8DC625;
@@ -9780,6 +9849,7 @@ UNUSED_Instruction_PaletteFXObject_GotoYPlusY_8DC623:
     ADC.B $12                                                            ;8DC635;
     TAY                                                                  ;8DC637;
     RTS                                                                  ;8DC638;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PaletteFXObject_DecrementTimer_GotoYIfNonZero:
@@ -9790,11 +9860,13 @@ Instruction_PaletteFXObject_DecrementTimer_GotoYIfNonZero:
     RTS                                                                  ;8DC640;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_PaletteFXObject_DecTimer_GotoYIfNonZero_8DC641:
     DEC.W $1EDD,X                                                        ;8DC641;
     BNE UNUSED_Instruction_PaletteFXObject_GotoYPlusY_8DC623             ;8DC644;
     INY                                                                  ;8DC646;
     RTS                                                                  ;8DC647;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PaletteFXObject_TimerInY:
@@ -9818,6 +9890,7 @@ Instruction_PaletteFXObject_ColorIndexInY:
     RTS                                                                  ;8DC65D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PaletteFXObject_QueueMusicTrackInY_8DC65E:
     LDA.W $0000,Y                                                        ;8DC65E;
     AND.W #$00FF                                                         ;8DC661;
@@ -9831,6 +9904,7 @@ UNUSED_Inst_PaletteFXObject_QueueSoundInY_Lib1_Max6_8DC66A:
     JSL.L QueueSound_Lib1_Max6                                           ;8DC66D;
     INY                                                                  ;8DC671;
     RTS                                                                  ;8DC672;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 UNUSED_Inst_PaletteFXObject_QueueSoundInY_Lib2_Max6_8DC673:
@@ -9840,19 +9914,23 @@ UNUSED_Inst_PaletteFXObject_QueueSoundInY_Lib2_Max6_8DC673:
     RTS                                                                  ;8DC67B;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Inst_PaletteFXObject_QueueSoundInY_Lib3_Max6_8DC67C:
     LDA.W $0000,Y                                                        ;8DC67C;
     JSL.L QueueSound_Lib3_Max6                                           ;8DC67F;
     INY                                                                  ;8DC683;
     RTS                                                                  ;8DC684;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_8DC685:
     RTS                                                                  ;8DC685;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_8DC686:
     dw $1000,$C690,$C595,$C61E,$C686,$0180,$0000,$0000                   ;8DC686;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PaletteFXObject_FadeInSuperMetroidTitleLogo:
     dw Instruction_PaletteFXObject_ColorIndexInY                         ;8DC696;
@@ -10594,6 +10672,7 @@ InstList_PaletteFXObject_HyperBeam_1:
     dw Instruction_PaletteFXObject_GotoY                                 ;8DD9CC;
     dw InstList_PaletteFXObject_HyperBeam_1                              ;8DD9CE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PaletteFXObject_8DD9D0:
     dw Instruction_PaletteFXObject_ColorIndexInY                         ;8DD9D0;
     dw $00A0,$0002,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF                   ;8DD9D2;
@@ -10641,6 +10720,7 @@ UNUSED_InstList_PaletteFXObject_8DD9D0:
     dw $4210                                                             ;8DDB5C;
     dw Instruction_PaletteFXObject_Done                                  ;8DDB5E;
     dw Instruction_Delete_8DC5CF                                         ;8DDB60;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PaletteFXObject_SamusLoading_PowerSuit_0:
     dw Instruction_PaletteFXObject_ColorIndexInY                         ;8DDB62;
@@ -10904,9 +10984,11 @@ PaletteFXObjects_FadeInSuperMetroidTitleLogo:
     dw RTS_8DC685                                                        ;8DE194;
     dw InstList_PaletteFXObject_FadeInSuperMetroidTitleLogo              ;8DE196;
 
+if !FEATURE_KEEP_UNREFERENCED
 PaletteFXObjects_FadeInNintendoBootLogoForUnusedCode:
     dw RTS_8DC685                                                        ;8DE198;
     dw InstList_PaletteFXObject_FadeInNintendoBootLogo                   ;8DE19A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PaletteFXObjects_FadeInNintendoCopyright:
     dw RTS_8DC685                                                        ;8DE19C;
@@ -10988,9 +11070,11 @@ PaletteFXObjects_WidePartOfZebesExplosion_Background:
     dw RTS_8DC685                                                        ;8DE1E8;
     dw InstList_PaletteFXObject_WidePartOfZebesExplosion_Background      ;8DE1EA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PaletteFXObjects_8DE1EC:
     dw RTS_8DC685                                                        ;8DE1EC;
     dw UNUSED_InstList_PaletteFXObject_8DD9D0                            ;8DE1EE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PaletteFXObjects_HyperBeam:
     dw RTS_8DC685                                                        ;8DE1F0;
@@ -11563,6 +11647,7 @@ InstList_PaletteFXObject_WreckedShip1_1:
     dw Instruction_PaletteFXObject_GotoY                                 ;8DEB26;
     dw InstList_PaletteFXObject_WreckedShip1_1                           ;8DEB28;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PreInstruction_PaletteFXObject_WaitUntilAreBossIsDead:
     LDA.W #$0001                                                         ;8DEB2A;
     JSL.L CheckIfBossBitsForCurrentAreaMatchAnyBitsInA                   ;8DEB2D;
@@ -11573,6 +11658,7 @@ UNUSED_PreInstruction_PaletteFXObject_WaitUntilAreBossIsDead:
 
 .return:
     RTS                                                                  ;8DEB3A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_PaletteFXObject_Crateria1_0:
@@ -11649,6 +11735,7 @@ PreInst_PaletteFXObject_RestartCrateria1IfSamusIsntLowEnough:
     RTS                                                                  ;8DEC6D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PaletteFXObject_DarkLightning_0_8DEC6E:
     dw Instruction_PaletteFXObject_PreInstructionInY                     ;8DEC6E;
     dw UNUSED_PreInst_PalFXObj_RestartDarkLightningIfSamus_8DED84        ;8DEC70;
@@ -11710,6 +11797,7 @@ UNUSED_PreInst_PalFXObj_RestartDarkLightningIfSamus_8DED84:
 
 .return:
     RTS                                                                  ;8DED98;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_PaletteFXObject_Brinstar1_0:
@@ -12416,9 +12504,11 @@ PaletteFXObjects_Crateria1_Lightning:
     dw RTS_8DC685                                                        ;8DF765;
     dw InstList_PaletteFXObject_Crateria1_0                              ;8DF767;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PaletteFXObjects_DarkLightning_8DF769:
     dw RTS_8DC685                                                        ;8DF769;
     dw UNUSED_InstList_PaletteFXObject_DarkLightning_0_8DEC6E            ;8DF76B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PaletteFXObjects_WreckedShip1_GreenLights:
     dw RTS_8DC685                                                        ;8DF76D;

--- a/src/bank_8F.asm
+++ b/src/bank_8F.asm
@@ -2095,8 +2095,10 @@ PLMPopulation_FastPillarsSetup:
     db $08,$1B                                                           ;8F8ECE;
     dw $8000,$0000                                                       ;8F8ED0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PLMPopulation_8FB3EE:
     dw $0000                                                             ;8F8ED4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMPopulation_MickeyMouse:
     dw PLMEntries_ScrollPLM                                              ;8F8ED6;
@@ -5266,11 +5268,13 @@ RoomDoors_Statues:
 RoomScrolls_Statues:
     db $01,$00                                                           ;8FA697;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FA699:
     db $00,$02,$01,$01,$80                                               ;8FA699;
 
 UNUSED_RoomPLM_8FA69E:
     db $01,$02,$80                                                       ;8FA69E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomHeader_WarehouseEntrance:
     db $34,$01,$29,$12,$03,$02,$70,$A0,$00                               ;8FA6A1;
@@ -5646,8 +5650,10 @@ RoomScrolls_CrocomireSpeedway:
     db $02,$02,$02,$02,$00,$00,$00,$00,$00,$02,$00,$00,$00,$00,$00,$02   ;8FA964;
     db $02,$02,$02,$02,$02,$00,$02                                       ;8FA974;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FA97B:
     db $19,$02,$26,$02,$80                                               ;8FA97B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomPLM_CrocomireSpeedway_0:
     db $19,$02,$25,$02,$26,$02,$80                                       ;8FA980;
@@ -5701,11 +5707,13 @@ RoomDoors_Crocomire:
 RoomScrolls_Crocomire:
     db $00,$00,$01,$01,$01,$01,$01,$01                                   ;8FA9D7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FA9DF:
     db $01,$01,$80                                                       ;8FA9DF;
 
 UNUSED_RoomPLM_8FA9E2:
     db $00,$01,$80                                                       ;8FA9E2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomHeader_HiJumpBoots:
     db $0B,$02,$07,$06,$01,$01,$70,$A0,$00                               ;8FA9E5;
@@ -6162,6 +6170,7 @@ RoomState_SpeedBooster:
     dw LibBG_Norfair_9_A_SmallPatternBrownPurple_Bright                  ;8FAD3E;
     dw RTS_8F91F6                                                        ;8FAD40;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomState_8FAD42:
     dl LevelData_SpeedBooster                                            ;8FAD42;
     db $09,$00,$03                                                       ;8FAD45;
@@ -6175,6 +6184,7 @@ UNUSED_RoomState_8FAD42:
     dw PLMPopulation_SpeedBooster                                        ;8FAD56;
     dw LibBG_Norfair_9_A_SmallPatternBrownPurple_Bright                  ;8FAD58;
     dw RTS_8F91F6                                                        ;8FAD5A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomDoors_SpeedBooster:
     dw Door_SpeedBooster_0                                               ;8FAD5C;
@@ -6838,8 +6848,10 @@ RoomDoors_AcidStatue:
 RoomScrolls_AcidStatue:
     db $02,$02,$00,$01,$01,$00,$00,$00,$00                               ;8FB210;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FB219:
     db $03,$01,$04,$01,$06,$00,$07,$00,$08,$00,$80                       ;8FB219;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomPLM_AcidStatue_0:
     db $03,$02,$04,$02,$06,$02,$07,$02,$80                               ;8FB224;
@@ -7074,6 +7086,7 @@ RoomPLM_FastPillarsSetup_0:
 RoomPLM_FastPillarsSetup_2:
     db $01,$02,$02,$01,$80                                               ;8FB3DC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomHeader_8FB3E1:
     db $3D,$02,$1A,$0B,$01,$01,$70,$A0,$00                               ;8FB3E1;
     dw UNUSED_RoomDoors_8FB408                                           ;8FB3EA;
@@ -7095,6 +7108,7 @@ UNUSED_RoomState_8FB3EE:
 
 UNUSED_RoomDoors_8FB408:
     dw UNUSED_Door_83991E                                                ;8FB408;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomHeader_MickeyMouse:
     db $3E,$02,$1A,$09,$04,$04,$70,$A0,$00                               ;8FB40A;
@@ -7636,6 +7650,7 @@ LibBG_Crocomire_State1:
     dl $7E2000                                                           ;8FB85A;
     dw $4800,$1000,$0000                                                 ;8FB85D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Brinstar_1A_Kraid_Lower_8FB863:
     dw $0004                                                             ;8FB863;
     dl Background_Brinstar_1A_Kraid_Lower_1                              ;8FB865;
@@ -7644,6 +7659,7 @@ UNUSED_LibBG_Brinstar_1A_Kraid_Lower_8FB863:
     dw $4800,$0800,$0002                                                 ;8FB86F;
     dl $7E4000                                                           ;8FB875;
     dw $4C00,$0800,$0000                                                 ;8FB878;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Crateria_0_VerticalPatternRocks:
     dw $0004                                                             ;8FB87E;
@@ -7928,6 +7944,7 @@ LibBG_Brinstar_6_SmallPattern_Variety_0:
     dl $7E4000                                                           ;8FBB06;
     dw $4C00,$0800,$0000                                                 ;8FBB09;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Brinstar_6_SmallPattern_Variety_1_8FBB0F:
     dw $0004                                                             ;8FBB0F;
     dl Background_Brinstar_6_SmallPattern_Variety_1                      ;8FBB11;
@@ -7945,6 +7962,7 @@ UNUSED_LibBG_Brinstar_6_SmallPattern_Variety_2_8FBB2A:
     dw $4800,$0800,$0002                                                 ;8FBB36;
     dl $7E4000                                                           ;8FBB3C;
     dw $4C00,$0800,$0000                                                 ;8FBB3F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Brinstar_6_DarkPattern:
     dw $0004                                                             ;8FBB45;
@@ -7973,6 +7991,7 @@ LibBG_Brinstar_7_WideVerticalTower_Brick_0:
     dl $7E4000                                                           ;8FBB8D;
     dw $4C00,$0800,$0000                                                 ;8FBB90;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Brinstar_7_WideVerticalTower_Brick_1_8FBB96:
     dw $0004                                                             ;8FBB96;
     dl Background_Brinstar_7_WideVerticalTower_Brick_1                   ;8FBB98;
@@ -7990,6 +8009,7 @@ UNUSED_LibBG_Brinstar_7_WideVerticalTower_Brick_2_8FBBB1:
     dw $4800,$0800,$0002                                                 ;8FBBBD;
     dl $7E4000                                                           ;8FBBC3;
     dw $4C00,$0800,$0000                                                 ;8FBBC6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Brinstar_7_VerticalTower:
     dw $0004                                                             ;8FBBCC;
@@ -8018,6 +8038,7 @@ LibBG_Brinstar_7_VerticalBrick_0:
     dl $7E4000                                                           ;8FBC14;
     dw $4C00,$0800,$0000                                                 ;8FBC17;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Brinstar_7_VerticalBrick_1_8FBC1D:
     dw $0004                                                             ;8FBC1D;
     dl Background_Brinstar_7_VerticalBrick_1                             ;8FBC1F;
@@ -8026,6 +8047,7 @@ UNUSED_LibBG_Brinstar_7_VerticalBrick_1_8FBC1D:
     dw $4800,$0800,$0002                                                 ;8FBC29;
     dl $7E4000                                                           ;8FBC2F;
     dw $4C00,$0800,$0000                                                 ;8FBC32;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Brinstar_7_MechanicalRoom_SpikeFloor:
     dw $0004                                                             ;8FBC38;
@@ -8054,6 +8076,7 @@ LibBG_Brinstar_7_NarrowVerticalTower_Brick_Vines_0:
     dl $7E4000                                                           ;8FBC80;
     dw $4C00,$0800,$0000                                                 ;8FBC83;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Brin_7_NarrowVerticalTower_Brick_Vines_1_8FBC89:
     dw $0004                                                             ;8FBC89;
     dl Background_Brinstar_7_NarrowVerticalTower_Brick_Vines_1           ;8FBC8B;
@@ -8062,6 +8085,7 @@ UNUSED_LibBG_Brin_7_NarrowVerticalTower_Brick_Vines_1_8FBC89:
     dw $4800,$0800,$0002                                                 ;8FBC95;
     dl $7E4000                                                           ;8FBC9B;
     dw $4C00,$0800,$0000                                                 ;8FBC9E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Brinstar_8_NarrowVerticalTower_Brick_Grey_0:
     dw $0004                                                             ;8FBCA4;
@@ -8070,6 +8094,7 @@ LibBG_Brinstar_8_NarrowVerticalTower_Brick_Grey_0:
     dl $7E4000                                                           ;8FBCAD;
     dw $4800,$1000,$0000                                                 ;8FBCB0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Brin_8_NarrowVerticalTower_Brick_Grey_1_8FBCB6:
     dw $0004                                                             ;8FBCB6;
     dl Background_Brinstar_8_NarrowVerticalTower_Brick_Grey_1            ;8FBCB8;
@@ -8087,6 +8112,7 @@ UNUSED_LibBG_Brin_8_NarrowVerticalTower_Brick_Grey_2_8FBCD1:
     dw $4800,$0800,$0002                                                 ;8FBCDD;
     dl $7E4000                                                           ;8FBCE3;
     dw $4C00,$0800,$0000                                                 ;8FBCE6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Brinstar_7_BlueGridBlocks:
     dw $0004                                                             ;8FBCEC;
@@ -8332,6 +8358,7 @@ LibBG_Norfair_9_A_SmallPatternBrownPurple_0:
     dl $7E4000                                                           ;8FBE6C;
     dw $4C00,$0800,$0000                                                 ;8FBE6F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_Norfair_9_A_SmallPatternBrownPurple_1_8FBE75:
     dw $0004                                                             ;8FBE75;
     dl Background_Norfair_9_A_SmallPatternBrownPurple_1                  ;8FBE77;
@@ -8340,6 +8367,7 @@ UNUSED_LibBG_Norfair_9_A_SmallPatternBrownPurple_1_8FBE75:
     dw $4800,$0800,$0002                                                 ;8FBE81;
     dl $7E4000                                                           ;8FBE87;
     dw $4C00,$0800,$0000                                                 ;8FBE8A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_Norfair_9_HorizontalPatternBrick:
     dw $0004                                                             ;8FBE90;
@@ -8490,6 +8518,7 @@ DoorASM_Scroll_A_Green:
     RTS                                                                  ;8FC004;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DoorASM_Scroll_0_Blue_2_Red_8FC005:
     PHP                                                                  ;8FC005;
     SEP #$20                                                             ;8FC006;
@@ -8499,6 +8528,7 @@ UNUSED_DoorASM_Scroll_0_Blue_2_Red_8FC005:
     STA.L $7ECD22                                                        ;8FC010;
     PLP                                                                  ;8FC014;
     RTS                                                                  ;8FC015;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DoorASM_Scroll_0_2_Green:
@@ -8805,8 +8835,10 @@ MainASM_ScrollScreenRightInDachoraRoom:
     RTS                                                                  ;8FC208;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_8FC209:
     dw $0051,$0061,$0001,$0002,$0005,$0006                               ;8FC209;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PLMPopulation_BowlingAlley_State0:
     dw PLMEntries_ScrollPLM                                              ;8FC215;
@@ -10009,6 +10041,7 @@ RoomPLM_BowlingAlley_0:
 RoomPLM_BowlingAlley_3:
     db $04,$00,$05,$02,$0B,$02,$10,$01,$11,$01,$80                       ;8FC9F1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FC9FC:
     db $05,$01,$80                                                       ;8FC9FC;
 
@@ -10020,6 +10053,7 @@ UNUSED_RoomPLM_8FCA02:
 
 UNUSED_RoomPLM_8FCA05:
     db $04,$00,$80                                                       ;8FCA05;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomHeader_WreckedShipEntrance:
     db $01,$03,$0C,$0E,$04,$01,$70,$A0,$00                               ;8FCA08;
@@ -10105,6 +10139,7 @@ RoomDoors_Attic:
 RoomScrolls_Attic:
     db $02,$02,$02,$02,$02,$02,$02                                       ;8FCA9E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FCAA5:
     db $00,$01,$80                                                       ;8FCAA5;
 
@@ -10113,6 +10148,7 @@ UNUSED_RoomPLM_8FCAA8:
 
 UNUSED_RoomPLM_8FCAAB:
     db $03,$02,$80                                                       ;8FCAAB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomHeader_AssemblyLine:
     db $03,$03,$13,$0A,$03,$01,$70,$A0,$00                               ;8FCAAE;
@@ -10394,8 +10430,10 @@ RoomPLM_Basement_0:
 RoomPLM_Basement_1:
     db $03,$00,$80                                                       ;8FCCC5;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomPLM_8FCCC8:
     db $04,$00,$80                                                       ;8FCCC8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomHeader_WreckedShipMap:
     db $09,$03,$0D,$13,$01,$01,$70,$A0,$00                               ;8FCCCB;
@@ -13213,6 +13251,7 @@ LibBG_WreckedShip_4_5_EntranceHall:
     dl $7E4000                                                           ;8FE129;
     dw $4C00,$0800,$0000                                                 ;8FE12C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibBG_WreckedShip_4_5_EntranceHall_1_8FE132:
     dw $0004                                                             ;8FE132;
     dl Background_WreckedShip_4_5_EntranceHall_1                         ;8FE134;
@@ -13221,6 +13260,7 @@ UNUSED_LibBG_WreckedShip_4_5_EntranceHall_1_8FE132:
     dw $4800,$0800,$0002                                                 ;8FE13E;
     dl $7E4000                                                           ;8FE144;
     dw $4C00,$0800,$0000                                                 ;8FE147;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LibBG_WreckedShip_4_5_Columns_Tubes:
     dw $0004                                                             ;8FE14D;
@@ -13450,6 +13490,7 @@ DoorASM_Scroll_A_Red_B_Blue:
     RTS                                                                  ;8FE328;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DoorASM_Scroll_4_Green_8FE329:
     PHP                                                                  ;8FE329;
     SEP #$20                                                             ;8FE32A;
@@ -13468,6 +13509,7 @@ UNUSED_DoorASM_Scroll_4_Green_8FE33A:
     STA.L $7ECD24                                                        ;8FE33F;
     PLP                                                                  ;8FE343;
     RTS                                                                  ;8FE344;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DoorASM_Scroll_0_Red_4_Blue_duplicate:
@@ -13542,6 +13584,7 @@ DoorASM_Scroll_4_Red_duplicate:
     RTS                                                                  ;8FE3AD;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DoorASM_Scroll_1_Red_8FE3AE:
     PHP                                                                  ;8FE3AE;
     SEP #$20                                                             ;8FE3AF;
@@ -13549,6 +13592,7 @@ UNUSED_DoorASM_Scroll_1_Red_8FE3AE:
     STA.L $7ECD21                                                        ;8FE3B3;
     PLP                                                                  ;8FE3B7;
     RTS                                                                  ;8FE3B8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DoorASM_Scroll_4_7_Red:
@@ -13824,6 +13868,7 @@ Use_StatePointer_inX:
     RTL                                                                  ;8FE5EA;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomStateCheck_Door_8FE5EB:
     LDA.W $0000,X                                                        ;8FE5EB;
     CMP.W $078D                                                          ;8FE5EE;
@@ -13838,6 +13883,7 @@ UNUSED_RoomStateCheck_Door_8FE5EB:
     INX                                                                  ;8FE5FC;
     INX                                                                  ;8FE5FD;
     RTS                                                                  ;8FE5FE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RoomStateCheck_MainAreaBossIsDead:
@@ -13886,6 +13932,7 @@ RoomStateCheck_BossIsDead:
     RTS                                                                  ;8FE63F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomStateCheck_Morphball_8FE640:
     LDA.W $09A4                                                          ;8FE640;
     AND.W #$0004                                                         ;8FE643;
@@ -13898,6 +13945,7 @@ UNUSED_RoomStateCheck_Morphball_8FE640:
   + INX                                                                  ;8FE64F;
     INX                                                                  ;8FE650;
     RTS                                                                  ;8FE651;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RoomStateCheck_MorphballAndMissiles:
@@ -13929,6 +13977,7 @@ RoomStateCheck_PowerBombs:
     RTS                                                                  ;8FE677;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RoomStateCheck_SpeedBooster_8FE678:
     LDA.W $09A4                                                          ;8FE678;
     AND.W #$2000                                                         ;8FE67B;
@@ -13941,6 +13990,7 @@ UNUSED_RoomStateCheck_SpeedBooster_8FE678:
   + INX                                                                  ;8FE687;
     INX                                                                  ;8FE688;
     RTS                                                                  ;8FE689;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Door_Closing_PLMs:
@@ -14182,6 +14232,7 @@ RoomDoors_Debug:
     dw UNUSED_Door_Debug_2_83ABDA                                        ;8FE857;
     dw UNUSED_Door_Debug_3_83ABE5                                        ;8FE859;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LibraryBackground_8FE85B:
     dw $0002                                                             ;8FE85B;
     dl FX_Layer3_Tilemaps_water                                          ;8FE85D;
@@ -14192,12 +14243,15 @@ UNUSED_LibraryBackground_8FE85B:
     dw $4800,$0800,$0002                                                 ;8FE870;
     dl $7E4000                                                           ;8FE876;
     dw $4C00,$0800,$0000                                                 ;8FE879;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RoomPLM_Debug:
     db $00,$00                                                           ;8FE87F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_UnknownUnreferenced_8FE881:
     dw $009E,$00AD,$0081,$0001,$0004,$0002,$0000                         ;8FE881;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Execute_Room_Setup_ASM:
     PHP                                                                  ;8FE88F;

--- a/src/bank_90.asm
+++ b/src/bank_90.asm
@@ -2097,6 +2097,7 @@ Samus_X_Movement:
     RTS                                                                  ;908E74;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusMovement_908E75:
     PHP                                                                  ;908E75;
     REP #$30                                                             ;908E76;
@@ -2126,6 +2127,7 @@ UNUSED_SamusMovement_908E75:
 .return:
     PLP                                                                  ;908EA7;
     RTS                                                                  ;908EA8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MoveSamus_Horizontally:
@@ -2762,6 +2764,7 @@ Simple_Samus_Y_Movement_duplicate:
     RTS                                                                  ;9092D5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveSamus_9092D6:
     PHP                                                                  ;9092D6;
     REP #$30                                                             ;9092D7;
@@ -2776,6 +2779,7 @@ UNUSED_MoveSamus_9092D6:
     STA.W $0B14                                                          ;9092E4;
     PLP                                                                  ;9092E7;
     RTS                                                                  ;9092E8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTS_9092E9:
@@ -3164,6 +3168,7 @@ ScrollingFinishedHook_SporeSpawnFight:
     RTS                                                                  ;909594;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CameraXSpeed_0_909595:
     PHP                                                                  ;909595;
     REP #$30                                                             ;909596;
@@ -3171,6 +3176,7 @@ UNUSED_CameraXSpeed_0_909595:
     STZ.W $0DA2                                                          ;90959B;
     PLP                                                                  ;90959E;
     RTS                                                                  ;90959F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Handle_Horizontal_Scrolling:
@@ -4689,8 +4695,10 @@ UNUSED_SamusMovement_7_90A32D:
     RTS                                                                  ;90A334;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_90A335:
     dw $001E                                                             ;90A335;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusMovementHandler_Normal:
     LDA.W $0A78                                                          ;90A337;
@@ -7336,6 +7344,7 @@ SuperMissileLink_HorizontalBlockCollisionDetection:
     RTS                                                                  ;90B4A5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ClearLinkedSuperMissileIfSuperMissileExplosion_90B4A6:
     PHP                                                                  ;90B4A6;
     REP #$30                                                             ;90B4A7;
@@ -7359,6 +7368,7 @@ UNUSED_ClearLinkedSuperMissileIfSuperMissileExplosion_90B4A6:
 .return:
     PLP                                                                  ;90B4C7;
     RTL                                                                  ;90B4C8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_BeamTrail_Empty:
@@ -9196,8 +9206,10 @@ ProjectileCooldowns_Uncharged:
 ProjectileCooldowns_Charged:
     db $1E,$1E,$1E,$1E,$1E,$1E,$1E,$1E,$1E,$1E,$1E,$1E,$00,$00,$00,$00   ;90C264;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Padding_90C274:
     db $00,$00,$00,$00,$00,$00                                           ;90C274;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileCooldowns_NonBeamProjectiles:
     db $00,$0A,$14,$28,$00,$10,$00,$00,$00                               ;90C27A;
@@ -11386,6 +11398,7 @@ ProjectilePreInstruction_SpeedEcho:
     RTS                                                                  ;90D524;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GrappleBeam_90D525:
     LDA.B $8B                                                            ;90D525;
     BIT.W $09B2                                                          ;90D527;
@@ -11447,6 +11460,7 @@ UNUSED_GrappleBeam_90D525:
     STA.W $0CFA                                                          ;90D59A;
     JSL.L UpdateGrappleBeamStartPositionDuringGrappleFire                ;90D59D;
     RTS                                                                  ;90D5A1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CrystalFlash:
@@ -13374,6 +13388,7 @@ Merge:
     RTS                                                                  ;90E359;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_90E35A:
     PHP                                                                  ;90E35A;
     PHB                                                                  ;90E35B;
@@ -13485,6 +13500,7 @@ UNUSED_ClearSamusSpecialFalling_90E400:
     PLB                                                                  ;90E418;
     PLP                                                                  ;90E419;
     RTL                                                                  ;90E41A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 UNUSED_SamusTimerHackHandler_SpecialFalling_90E41B:
@@ -14684,6 +14700,7 @@ SamusDisplayHandler_ShinesparkCrashCircle:
     RTS                                                                  ;90EC02;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusDisplayHandler_DrawSamusEchoes_90EC03:
     JSR.W SamusDrawingHandler_Default                                    ;90EC03;
     LDX.W #$0002                                                         ;90EC06;
@@ -14700,6 +14717,7 @@ UNUSED_SamusDisplayHandler_DrawSamusEchoes_90EC03:
 
 RTS_90EC13:
     RTS                                                                  ;90EC13;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 SamusDisplayHandler_UsingElevator:
@@ -14875,6 +14893,7 @@ RTS_90ED1E:
     RTS                                                                  ;90ED1E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_WasteTime_90ED1F:
     LDX.W #$00C8                                                         ;90ED1F;
 
@@ -14882,6 +14901,7 @@ UNUSED_WasteTime_90ED1F:
     DEX                                                                  ;90ED22;
     BPL .loop                                                            ;90ED23;
     RTS                                                                  ;90ED25;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DemoRecorder_DisplaySamusPositionAsAmmoIfMorphed:
@@ -14914,6 +14934,7 @@ DemoRecorder_DisplaySamusPositionAsAmmoIfMorphed:
     db $00,$00,$00,$00,$01,$00,$00,$01,$01,$01,$00,$00,$00,$00,$00,$00   ;90ED50;
     db $00,$01,$01,$01,$00,$00,$00,$00,$00,$00,$00,$00                   ;90ED60;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DisplayInGameTimeAsAmmo_90ED6C:
     LDA.W $09E0                                                          ;90ED6C;
     STA.W $09C6                                                          ;90ED6F;
@@ -14925,6 +14946,7 @@ UNUSED_DisplayInGameTimeAsAmmo_90ED6C:
     STA.W $09CE                                                          ;90ED81;
     STA.W $09D0                                                          ;90ED84;
     RTS                                                                  ;90ED87;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 FootstepGraphics:
@@ -15139,8 +15161,10 @@ UpdateSamusEchoPosition:
     RTS                                                                  ;90EF1B;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PossiblyFootStepGraphicOffsets_90EF1C:
     dw $000C,$0010                                                       ;90EF1C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Unknown_ShinesparkMovementHandler_Unused_90EF20:
     dw $0010                                                             ;90EF20;
@@ -15176,6 +15200,7 @@ PostGrappleCollisionDetection:
     RTL                                                                  ;90EF5D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FireUnknownProjectile27_90EF5E:
     LDA.W #RTS_90E90E                                                    ;90EF5E;
     STA.W $0A58                                                          ;90EF61;
@@ -15309,6 +15334,7 @@ UNUSED_SamusMovementHandler_90F072:
 
 .return:
     RTS                                                                  ;90F083;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Run_Samus_Command:
@@ -15967,6 +15993,7 @@ SamusCommand_1F_KillGrappleBeam:
     RTS                                                                  ;90F506;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ResumeSounds_90F507:
     LDA.W $0A1F                                                          ;90F507;
     AND.W #$00FF                                                         ;90F50A;
@@ -15986,6 +16013,7 @@ UNUSED_ResumeSounds_90F507:
 .return:
     CLC                                                                  ;90F52D;
     RTS                                                                  ;90F52E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DebugCommandHandler:

--- a/src/bank_91.asm
+++ b/src/bank_91.asm
@@ -146,6 +146,7 @@ NormalSamusPoseInputHandler_Falling:
     RTS                                                                  ;9180BD;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AutoJumpFromCrouchFall_9180BE:
     LDA.W $0A1C                                                          ;9180BE;
     CMP.W #$0029                                                         ;9180C1;
@@ -186,6 +187,7 @@ UNUSED_AutoJumpFromCrouchFall_9180BE:
 .return:
     PLP                                                                  ;918108;
     RTS                                                                  ;918109;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 NormalSamusPoseInputHandler_MorphBall_Falling:
@@ -951,6 +953,7 @@ Draw_RecordedDemoDuration:
     RTS                                                                  ;9185CD;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DemoInput_JumpLeft_GiveControlBack_9185CE:
     dw $001E,$0000,$0000,$0001,$0200,$0200,$001A,$0200                   ;9185CE;
     dw $0000,$0001,$0280,$0080,$0034,$0280,$0000,$001E                   ;9185DE;
@@ -965,6 +968,7 @@ Instruction_EndDemoInput_GiveControlBackToPlayer:
     STA.W $0A44                                                          ;918605;
     JSL.L Disable_DemoInput                                              ;918608;
     RTS                                                                  ;91860C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 InstList_DemoInput_BabyMetroidDiscovery_RunningLeft_0:
@@ -1034,6 +1038,7 @@ InstList_DemoInput_OldMotherBrainFight:
     dw $0000,$0001,$0040,$0040,$001D,$0040,$0000,$0046                   ;9186A4;
     dw $0000,$0000                                                       ;9186B4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DemoInput_OldMotherBrainFight_9186B8:
     dw $0014,$0000,$0000,$0001,$0200,$0200,$0007,$0200                   ;9186B8;
     dw $0000,$0001,$0280,$0080,$0007,$0280,$0000,$0004                   ;9186C8;
@@ -1066,6 +1071,7 @@ UNUSED_Instruction_EndDemoInputWithSamusFacingLeft_9186FE:
     PLY                                                                  ;918736;
     PLX                                                                  ;918737;
     RTS                                                                  ;918738;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_EndDemoInputWithSamusFacingLeft:
@@ -1093,16 +1099,20 @@ Instruction_EndDemoInputWithSamusFacingLeft:
     RTS                                                                  ;918773;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DemoInput_Delete_918774:
     dw Instruction_DemoInputObject_Delete                                ;918774;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DemoInput_Delete:
     dw Instruction_DemoInputObject_Delete                                ;918776;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DemoInputObject_Intro_JumpLeft_GiveControlBack_918778:
     dw RTS_9183BF                                                        ;918778;
     dw RTS_9183BF                                                        ;91877A;
     dw UNUSED_InstList_DemoInput_JumpLeft_GiveControlBack_9185CE         ;91877C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DemoInputObjects_Intro_BabyMetroidDiscovery:
     dw RTS_9183BF                                                        ;91877E;
@@ -1114,10 +1124,12 @@ DemoInputObjects_Intro_OldMotherBrainFight:
     dw RTS_9183BF                                                        ;918786;
     dw InstList_DemoInput_OldMotherBrainFight                            ;918788;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DemoInputObjects_Intro_OldMotherBrainFight_91878A:
     dw RTS_9183BF                                                        ;91878A;
     dw RTS_9183BF                                                        ;91878C;
     dw UNUSED_InstList_DemoInput_OldMotherBrainFight_9186B8              ;91878E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LoadDemoData:
     LDA.W $1F57                                                          ;918790;
@@ -1634,6 +1646,7 @@ InstList_DemoInput_BrinstarDiagonalRoom:
     dw $0440,$0000,$00DB,$0000,$0000                                     ;9195B0;
     dw Instruction_DemoInputObject_Delete                                ;9195BA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DemoInput_9195BC:
     dw $0029,$0000,$0000,$0001,$0200,$0200,$0018,$0200                   ;9195BC;
     dw $0000,$0011,$0000,$0000,$0001,$0080,$0080,$0018                   ;9195CC;
@@ -1646,6 +1659,7 @@ UNUSED_InstList_DemoInput_9195BC:
     dw $0000,$0000,$0001,$0400,$0400,$0005,$0400,$0000                   ;91963C;
     dw $0001,$0600,$0200,$0096,$0000,$0000                               ;91964C;
     dw Instruction_DemoInputObject_Delete                                ;919658;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DemoInput_PreSporeSpawnHall:
     dw $001B,$0000,$0000,$0001,$0200,$0200,$0005,$0200                   ;91965A;
@@ -1875,10 +1889,12 @@ DemoInputObjects_Title_BrinstarDiagonalRoom:
     dw PreInstruction_DemoInput_Normal                                   ;919EA2;
     dw InstList_DemoInput_BrinstarDiagonalRoom                           ;919EA4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DemoInputObjects_Title_919EA6:
     dw RTS_9183BF                                                        ;919EA6;
     dw PreInstruction_DemoInput_Normal                                   ;919EA8;
     dw UNUSED_InstList_DemoInput_9195BC                                  ;919EAA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DemoInputObjects_Title_PreSporeSpawnHall:
     dw RTS_9183BF                                                        ;919EAC;
@@ -2382,20 +2398,24 @@ UNUSED_TransitionTable_46_91A7E0:
 UNUSED_TransitionTable_47_91A7F4:
     dw $FFFF                                                             ;91A7F4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TransitionTable_PossiblyPartOfAbove_91A7F6:
     dw $0080,$0000,$004B,$0400,$0000,$0035,$0000,$0210                   ;91A7F6;
     dw $0078,$0000,$0220,$0076,$0000,$0240,$004A,$0000                   ;91A806;
     dw $0100,$0009,$0000,$0200,$0025,$0000,$0800,$0003                   ;91A816;
     dw $0000,$0010,$0005,$0000,$0020,$0007,$FFFF                         ;91A826;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_TransitionTable_48_91A834:
     dw $FFFF                                                             ;91A834;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TransitionTable_PossiblyPartOfAbove_91A836:
     dw $0080,$0000,$004C,$0400,$0000,$0036,$0000,$0120                   ;91A836;
     dw $0077,$0000,$0110,$0075,$0000,$0140,$0049,$0000                   ;91A846;
     dw $0200,$000A,$0000,$0100,$0026,$0000,$0800,$0004                   ;91A856;
     dw $0000,$0010,$0006,$0000,$0020,$0008,$FFFF                         ;91A866;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 TransitionTable_49_75_77_FacingLeft_Moonwalk:
     dw $0400,$0000,$0036,$0080,$0000,$00C0,$0080,$0010                   ;91A874;
@@ -2415,6 +2435,7 @@ TransitionTable_53_FacingRight_Knockback:
 TransitionTable_54_FacingLeft_Knockback:
     dw $0000,$0180,$004F,$FFFF                                           ;91A8EC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TransitionTable_91A8F4:
     dw $FFFF                                                             ;91A8F4;
 
@@ -2426,6 +2447,7 @@ UNUSED_TransitionTable_91A8F8:
 
 UNUSED_TransitionTable_91A8FA:
     dw $FFFF                                                             ;91A8FA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_TransitionTable_5B_91A8FC:
     dw $0000,$0280,$0066,$FFFF                                           ;91A8FC;
@@ -2914,8 +2936,10 @@ AnimationDelayTable:
 AnimationDelays_09_0A_0B_0C_0D_0E_0F_10_11_12_45_46:
     db $02,$03,$02,$03,$02,$03,$02,$03,$02,$03,$FF                       ;91B20A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AnimationDelays_91B215:
     db $04,$04,$04,$04,$04,$04,$03,$04,$04,$03,$FF,$0A,$FF               ;91B215;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AnimationDelays_03_04_85_86:
     db $02,$10,$FE,$01                                                   ;91B222;
@@ -3058,8 +3082,10 @@ AnimationDelays_2D_2E:
 AnimationDelays_53_54:
     db $02,$10,$FE,$01                                                   ;91B36A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AnimationDelays_91B36E:
     db $06,$06,$06,$08,$FF,$08,$08,$FF,$0A,$FF                           ;91B36E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AnimationDelays_Various_91B378:
     db $03,$03,$03,$03,$03,$03,$03,$03,$FF,$03,$FE,$0A                   ;91B378;
@@ -9074,6 +9100,7 @@ RTS_91DD31:
     RTS                                                                  ;91DD31;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_91DD32:
     db $01,$00,$00,$01,$00,$00,$01,$00,$00,$01,$01,$00,$01,$00,$01,$00   ;91DD32;
     db $01,$00,$01,$00,$01,$00,$01,$00,$01,$00                           ;91DD42;
@@ -9089,6 +9116,7 @@ UNUSED_SetSamusPaletteToSolidWhite_91DD4C:
     PLB                                                                  ;91DD58;
     PLP                                                                  ;91DD59;
     RTL                                                                  ;91DD5A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Load20BytesOfSamusPaletteInX:
@@ -11155,6 +11183,7 @@ ProspectivePoseCmd_8_KillRunSpeed:
     RTS                                                                  ;91EC9C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_91EC9D:
     LDA.W $0A1F                                                          ;91EC9D;
     AND.W #$00FF                                                         ;91ECA0;
@@ -11173,6 +11202,7 @@ UNUSED_91EC9D:
 .data:
     db $00,$00,$02,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00   ;91ECB4;
     db $00,$00,$00,$00,$00,$00,$00,$00,$00,$02,$00,$00                   ;91ECC4;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProspectivePoseCmd_2_Stop:
     STZ.W $0B4A                                                          ;91ECD0;

--- a/src/bank_92.asm
+++ b/src/bank_92.asm
@@ -2239,10 +2239,12 @@ UNUSED_Debug_SamusSpritemap_1_9290F4:
     db $E8                                                               ;929170;
     dw $3145                                                             ;929171;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_929173:
     dw $0001,$0000                                                       ;929173;
     db $00                                                               ;929177;
     dw $3A5F                                                             ;929178;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTileViewer_SamusTopHalf:
     dw $0010,$0018                                                       ;92917A;
@@ -9158,6 +9160,7 @@ SamusTopTiles_Set0_CCB9:
     dl SamusTiles_Top_Set0_Entry1D                                       ;92CCB9;
     dw $0100,$00C0                                                       ;92CCBC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set0_92CCC0:
     dl SamusTiles_Top_Set0_Entry1E                                       ;92CCC0;
     dw $0100,$0040                                                       ;92CCC3;
@@ -9165,14 +9168,17 @@ UNUSED_SamusTopTiles_Set0_92CCC0:
 UNUSED_SamusTopTiles_Set0_92CCC7:
     dl SamusTiles_Top_Set0_Entry1F                                       ;92CCC7;
     dw $0100,$0040                                                       ;92CCCA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_SamusTopTiles_Set1_92CCCE:
     dl SamusTiles_Top_Set1_Entry0                                        ;92CCCE;
     dw $00C0,$0080                                                       ;92CCD1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set1_92CCD5:
     dl SamusTiles_Top_Set1_Entry1                                        ;92CCD5;
     dw $00C0,$0080                                                       ;92CCD8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set1_CCDC:
     dl SamusTiles_Top_Set1_Entry2                                        ;92CCDC;
@@ -9254,6 +9260,7 @@ SamusTopTiles_Set1_CD61:
     dl SamusTiles_Top_Set1_Entry15                                       ;92CD61;
     dw $0100,$00C0                                                       ;92CD64;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set1_92CD68:
     dl SamusTiles_Top_Set1_Entry16                                       ;92CD68;
     dw $0020,$0000                                                       ;92CD6B;
@@ -9261,6 +9268,7 @@ UNUSED_SamusTopTiles_Set1_92CD68:
 UNUSED_SamusTopTiles_Set1_92CD6F:
     dl SamusTiles_Top_Set1_Entry17                                       ;92CD6F;
     dw $0020,$0000                                                       ;92CD72;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set1_CD76:
     dl SamusTiles_Top_Set1_Entry18                                       ;92CD76;
@@ -9294,9 +9302,11 @@ SamusTopTiles_Set2_CDA7:
     dl SamusTiles_Top_Set2_Entry1                                        ;92CDA7;
     dw $0080,$0080                                                       ;92CDAA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set2_92CDAE:
     dl SamusTiles_Top_Set2_Entry2                                        ;92CDAE;
     dw $00C0,$0080                                                       ;92CDB1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set2_CDB5:
     dl SamusTiles_Top_Set2_Entry3                                        ;92CDB5;
@@ -9358,6 +9368,7 @@ SamusTopTiles_Set2_CE17:
     dl SamusTiles_Top_Set2_Entry11                                       ;92CE17;
     dw $00E0,$0040                                                       ;92CE1A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set2_92CE1E:
     dl SamusTiles_Top_Set2_Entry12                                       ;92CE1E;
     dw $0100,$0040                                                       ;92CE21;
@@ -9373,6 +9384,7 @@ UNUSED_SamusTopTiles_Set2_92CE2C:
 UNUSED_SamusTopTiles_Set2_92CE33:
     dl SamusTiles_Top_Set2_Entry15                                       ;92CE33;
     dw $0100,$0040                                                       ;92CE36;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set2_CE3A:
     dl SamusTiles_Top_Set2_Entry16                                       ;92CE3A;
@@ -9478,9 +9490,11 @@ SamusTopTiles_Set3_CEE9:
     dl SamusTiles_Top_Set3_EntryF                                        ;92CEE9;
     dw $00C0,$0080                                                       ;92CEEC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set3_92CEF0:
     dl SamusTiles_Top_Set3_Entry10                                       ;92CEF0;
     dw $00C0,$0080                                                       ;92CEF3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set4_CEF7:
     dl SamusTiles_Top_Set4_Entry0                                        ;92CEF7;
@@ -9546,9 +9560,11 @@ SamusTopTiles_Set4_CF60:
     dl SamusTiles_Top_Set4_EntryF                                        ;92CF60;
     dw $0100,$00E0                                                       ;92CF63;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set4_92CF67:
     dl SamusTiles_Top_Set4_Entry10                                       ;92CF67;
     dw $0100,$00E0                                                       ;92CF6A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set5_CF6E:
     dl SamusTiles_Top_Set5_Entry0                                        ;92CF6E;
@@ -9614,9 +9630,11 @@ SamusTopTiles_Set5_CFD7:
     dl SamusTiles_Top_Set5_EntryF                                        ;92CFD7;
     dw $00C0,$0080                                                       ;92CFDA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set5_92CFDE:
     dl SamusTiles_Top_Set5_Entry10                                       ;92CFDE;
     dw $00C0,$0080                                                       ;92CFE1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set6_CFE5:
     dl SamusTiles_Top_Set6_Entry0                                        ;92CFE5;
@@ -9682,9 +9700,11 @@ SamusTopTiles_Set6_D04E:
     dl SamusTiles_Top_Set6_EntryF                                        ;92D04E;
     dw $0100,$00E0                                                       ;92D051;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set6_92D055:
     dl SamusTiles_Top_Set6_Entry10                                       ;92D055;
     dw $0100,$00E0                                                       ;92D058;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set7_D05C:
     dl SamusTiles_Top_Set7_Entry0                                        ;92D05C;
@@ -9770,9 +9790,11 @@ SamusTopTiles_Set8_D0E8:
     dl SamusTiles_Top_Set8_Entry0                                        ;92D0E8;
     dw $0020,$0000                                                       ;92D0EB;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_Set8_92D0EF:
     dl SamusTiles_Top_Set8_Entry1                                        ;92D0EF;
     dw $0020,$0000                                                       ;92D0F2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_Set8_D0F6:
     dl SamusTiles_Top_Set8_Entry2                                        ;92D0F6;
@@ -10062,9 +10084,11 @@ SamusBottomTiles_Set1_D2E7:
     dl SamusTiles_Bottom_Set1_EntryF                                     ;92D2E7;
     dw $00C0,$0040                                                       ;92D2EA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set1_92D2EE:
     dl SamusTiles_Bottom_Set1_Entry10                                    ;92D2EE;
     dw $0020,$0000                                                       ;92D2F1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set1_D2F5:
     dl SamusTiles_Bottom_Set1_Entry11                                    ;92D2F5;
@@ -10114,9 +10138,11 @@ SamusBottomTiles_Set1_D342:
     dl SamusTiles_Bottom_Set1_Entry1C                                    ;92D342;
     dw $00C0,$0080                                                       ;92D345;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set1_92D349:
     dl SamusTiles_Bottom_Set1_Entry1D                                    ;92D349;
     dw $0080,$0080                                                       ;92D34C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set1_D350:
     dl SamusTiles_Bottom_Set1_Entry1E                                    ;92D350;
@@ -10166,9 +10192,11 @@ SamusBottomTiles_Set2_D39D:
     dl SamusTiles_Bottom_Set2_Entry9                                     ;92D39D;
     dw $00C0,$0040                                                       ;92D3A0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set2_92D3A4:
     dl SamusTiles_Bottom_Set2_EntryA                                     ;92D3A4;
     dw $00A0,$0080                                                       ;92D3A7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set2_D3AB:
     dl SamusTiles_Bottom_Set2_EntryB                                     ;92D3AB;
@@ -10218,9 +10246,11 @@ SamusBottomTiles_Set2_D3F8:
     dl SamusTiles_Bottom_Set2_Entry16                                    ;92D3F8;
     dw $0080,$0080                                                       ;92D3FB;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set2_92D3FF:
     dl SamusTiles_Bottom_Set2_Entry17                                    ;92D3FF;
     dw $0080,$0080                                                       ;92D402;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set4_D406:
     dl SamusTiles_Bottom_Set4_Entry0                                     ;92D406;
@@ -10262,6 +10292,7 @@ SamusBottomTiles_Set4_D445:
     dl SamusTiles_Bottom_Set4_Entry9                                     ;92D445;
     dw $00C0,$0040                                                       ;92D448;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set4_92D44C:
     dl SamusTiles_Bottom_Set4_EntryA                                     ;92D44C;
     dw $00A0,$0080                                                       ;92D44F;
@@ -10273,6 +10304,7 @@ UNUSED_SamusBottomTiles_Set4_92D453:
 UNUSED_SamusBottomTiles_Set4_92D45A:
     dl SamusTiles_Bottom_Set4_EntryC                                     ;92D45A;
     dw $0080,$0080                                                       ;92D45D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set4_D461:
     dl SamusTiles_Bottom_Set4_EntryD                                     ;92D461;
@@ -10310,9 +10342,11 @@ SamusBottomTiles_Set4_D499:
     dl SamusTiles_Bottom_Set4_Entry15                                    ;92D499;
     dw $0080,$0080                                                       ;92D49C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set4_92D4A0:
     dl SamusTiles_Bottom_Set4_Entry16                                    ;92D4A0;
     dw $0080,$0080                                                       ;92D4A3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set5_D4A7:
     dl SamusTiles_Bottom_Set5_Entry0                                     ;92D4A7;
@@ -10354,9 +10388,11 @@ SamusBottomTiles_Set5_D4E6:
     dl SamusTiles_Bottom_Set5_Entry9                                     ;92D4E6;
     dw $00C0,$0040                                                       ;92D4E9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set5_92D4ED:
     dl SamusTiles_Bottom_Set5_EntryA                                     ;92D4ED;
     dw $00A0,$0080                                                       ;92D4F0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set5_D4F4:
     dl SamusTiles_Bottom_Set5_EntryB                                     ;92D4F4;
@@ -10366,9 +10402,11 @@ SamusBottomTiles_Set5_D4FB:
     dl SamusTiles_Bottom_Set5_EntryC                                     ;92D4FB;
     dw $0080,$0080                                                       ;92D4FE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set5_92D502:
     dl SamusTiles_Bottom_Set5_EntryD                                     ;92D502;
     dw $0080,$0080                                                       ;92D505;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set5_D509:
     dl SamusTiles_Bottom_Set5_EntryE                                     ;92D509;
@@ -10406,9 +10444,11 @@ SamusBottomTiles_Set5_D541:
     dl SamusTiles_Bottom_Set5_Entry16                                    ;92D541;
     dw $0080,$0080                                                       ;92D544;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set5_92D548:
     dl SamusTiles_Bottom_Set5_Entry17                                    ;92D548;
     dw $0080,$0080                                                       ;92D54B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set6_D54F:
     dl SamusTiles_Bottom_Set6_Entry0                                     ;92D54F;
@@ -10450,6 +10490,7 @@ SamusBottomTiles_Set6_D58E:
     dl SamusTiles_Bottom_Set6_Entry9                                     ;92D58E;
     dw $00C0,$0040                                                       ;92D591;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set6_92D595:
     dl SamusTiles_Bottom_Set6_EntryA                                     ;92D595;
     dw $00A0,$0080                                                       ;92D598;
@@ -10461,6 +10502,7 @@ UNUSED_SamusBottomTiles_Set6_92D59C:
 UNUSED_SamusBottomTiles_Set6_92D5A3:
     dl SamusTiles_Bottom_Set6_EntryC                                     ;92D5A3;
     dw $0080,$0080                                                       ;92D5A6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_Set6_D5AA:
     dl SamusTiles_Bottom_Set6_EntryD                                     ;92D5AA;
@@ -10510,9 +10552,11 @@ SamusBottomTiles_Set8_D5F7:
     dl SamusTiles_Bottom_Set8_Entry1                                     ;92D5F7;
     dw $0100,$0100                                                       ;92D5FA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set8_92D5FE:
     dl SamusTiles_Bottom_Set8_Entry2                                     ;92D5FE;
     dw $0020,$0000                                                       ;92D601;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusBottomTiles_SetA_D605:
     dl SamusTiles_Bottom_SetA_Entry0                                     ;92D605;
@@ -10614,9 +10658,11 @@ SamusTopTiles_SetB_D6AD:
     dl SamusTiles_Top_SetB_Entry1                                        ;92D6AD;
     dw $0060,$0040                                                       ;92D6B0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTopTiles_SetB_92D6B4:
     dl SamusTiles_Top_SetB_Entry2                                        ;92D6B4;
     dw $0060,$0040                                                       ;92D6B7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_SetB_D6BB:
     dl SamusTiles_Top_SetB_Entry3                                        ;92D6BB;
@@ -10638,6 +10684,7 @@ UNUSED_SamusBottomTiles_Set3_92D6D7:
     dl UNUSED_SamusTiles_Bottom_Set3_Entry0_9EE9C0                       ;92D6D7;
     dw $0040,$0040                                                       ;92D6DA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusBottomTiles_Set3_92D6DE:
     dl UNUSED_SamusTiles_Bottom_Set3_Entry1_9EEA40                       ;92D6DE;
     dw $0080,$0080                                                       ;92D6E1;
@@ -10701,6 +10748,7 @@ UNUSED_SamusBottomTiles_Set3_92D740:
 UNUSED_SamusBottomTiles_Set3_92D747:
     dl UNUSED_SamusTiles_Bottom_Set3_Entry10_9EF5C0                      ;92D747;
     dw $0080,$0080                                                       ;92D74A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusTopTiles_SetC_D74E:
     dl SamusTiles_Top_SetC_Entry0                                        ;92D74E;

--- a/src/bank_93.asm
+++ b/src/bank_93.asm
@@ -357,6 +357,7 @@ Instruction_SamusProjectile_GotoY:
     RTS                                                                  ;93823F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_SamusProj_GotoY_BasedOnBombTimer_938240:
     REP #$30                                                             ;938240;
     LDA.W $0000,Y                                                        ;938242;
@@ -371,6 +372,7 @@ UNUSED_Instruction_SamusProj_GotoY_BasedOnBombTimer_938240:
     LDA.W $0002,Y                                                        ;93824F;
     TAY                                                                  ;938252;
     RTS                                                                  ;938253;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DrawProjectiles:
@@ -475,6 +477,7 @@ DrawProjectiles:
     RTL                                                                  ;9382FC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PartialDrawProjectiles_9282FD:
     PHP                                                                  ;9382FD;
     REP #$30                                                             ;9382FE;
@@ -521,6 +524,7 @@ UNUSED_PartialDrawProjectiles_9282FD:
     JSL.L HandleProjectileTrails                                         ;938347;
     PLP                                                                  ;93834B;
     RTL                                                                  ;93834C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DrawBombsAndProjectileExplosions:
@@ -1020,8 +1024,10 @@ ProjectileDataTable_NonBeam_MissileExplosion:
 ProjectileDataTable_NonBeam_MissileExplosion_pointer:
     dw InstList_SamusProjectile_MissileExplosion                         ;93867F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileDataTable_NonBeam_BombExplosion_938681:
     dw $0000                                                             ;938681;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileDataTable_NonBeam_BombExplosion_pointer:
     dw InstList_SamusProjectile_BombExplosion                            ;938683;
@@ -1038,8 +1044,10 @@ ProjectileDataTable_NonBeam_SpazerSBA:
     dw $012C                                                             ;93868D;
     dw InstList_SamusProjectile_Spazer_SpazerIce_Up_0                    ;93868F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjDataTable_NonBeam_SuperMissileExplosion_938691:
     dw $0008                                                             ;938691;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileDataTable_NonBeam_SuperMissileExplosion_pointer:
     dw InstList_SamusProjectile_SuperMissileExplosion                    ;938693;
@@ -4220,6 +4228,7 @@ FlareSpritemapTable_IndexOffsets_facingRight:
 FlareSpritemapTable_IndexOffsets_facingLeft:
     dw $0000,$002A,$0030                                                 ;93A22B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93A231:
     dw $0001,$01FC                                                       ;93A231;
     db $FC                                                               ;93A235;
@@ -4239,6 +4248,7 @@ UNUSED_ProjectileFlareSpritemaps_93A246:
     dw $0001,$01FC                                                       ;93A246;
     db $FC                                                               ;93A24A;
     dw $3A28                                                             ;93A24B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Power_0:
     dw $0001,$01FC                                                       ;93A24D;
@@ -4280,6 +4290,7 @@ ProjectileFlareSpritemaps_Power_7:
     db $FC                                                               ;93A282;
     dw $AC31                                                             ;93A283;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93A285:
     dw $0001,$01FC                                                       ;93A285;
     db $FC                                                               ;93A289;
@@ -4431,6 +4442,7 @@ UNUSED_ProjectileFlareSpritemaps_93A376:
     dw $0001,$01FC                                                       ;93A376;
     db $FC                                                               ;93A37A;
     dw $2C3B                                                             ;93A37B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Plasma_PlasmaIce_0:
     dw $0004,$0008                                                       ;93A37D;
@@ -4484,6 +4496,7 @@ ProjectileFlareSpritemaps_Plasma_PlasmaIce_3:
     db $F4                                                               ;93A3E6;
     dw $6C31                                                             ;93A3E7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93A3E9:
     dw $0004,$0008                                                       ;93A3E9;
     db $FC                                                               ;93A3ED;
@@ -4862,6 +4875,7 @@ UNUSED_ProjectileFlareSpritemaps_93A6E7:
     dw $7C50,$01F8                                                       ;93A6F6;
     db $F8                                                               ;93A6FA;
     dw $3C50                                                             ;93A6FB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_FlareSlowSparks_FacingRight_0:
     dw $0003,$0000                                                       ;93A6FD;
@@ -5097,6 +5111,7 @@ ProjectileFlareSpritemaps_BombExplosion_PlasmaSBA_5:
     db $F8                                                               ;93A8BF;
     dw $3A5E                                                             ;93A8C0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93A8C2:
     dw $0001,$01FC                                                       ;93A8C2;
     db $FC                                                               ;93A8C6;
@@ -5116,6 +5131,7 @@ UNUSED_ProjectileFlareSpritemaps_93A8D7:
     dw $0001,$01FC                                                       ;93A8D7;
     db $FC                                                               ;93A8DB;
     dw $3C3B                                                             ;93A8DC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_FlareSlowSparks_FacingLeft_0:
     dw $0003,$01F8                                                       ;93A8DE;
@@ -5225,6 +5241,7 @@ ProjectileFlareSpritemaps_FlareFastSparks_FacingLeft_5:
     db $02                                                               ;93A9A7;
     dw $EC5D                                                             ;93A9A8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93A9AA:
     dw $0001,$01F7                                                       ;93A9AA;
     db $F7                                                               ;93A9AE;
@@ -5342,6 +5359,7 @@ UNUSED_ProjectileFlareSpritemaps_93AA6E:
     dw $BC63,$01F8                                                       ;93AA7D;
     db $F8                                                               ;93AA81;
     dw $3C63                                                             ;93AA82;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_SuperMissileExplosion_0:
     dw $0004,$0000                                                       ;93AA84;
@@ -5490,10 +5508,12 @@ ProjectileFlareSpritemaps_PowerBomb_2:
     db $FC                                                               ;93ABA9;
     dw $3A7B                                                             ;93ABAA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93ABAC:
     dw $0001,$01FC                                                       ;93ABAC;
     db $FC                                                               ;93ABB0;
     dw $3A5F                                                             ;93ABB1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_BeamExplosion_0:
     dw $0001,$01FC                                                       ;93ABB3;
@@ -5549,6 +5569,7 @@ ProjectileFlareSpritemaps_BeamExplosion_5:
     db $F8                                                               ;93AC16;
     dw $3C63                                                             ;93AC17;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93AC19:
     dw $0004,$01F2                                                       ;93AC19;
     db $FC                                                               ;93AC1D;
@@ -5734,6 +5755,7 @@ UNUSED_ProjectileFlareSpritemaps_93AC3E:
     dw $0001,$01FC                                                       ;93AD3E;
     db $FC                                                               ;93AD42;
     dw $3A42                                                             ;93AD43;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Bomb_0:
     dw $0001,$01FC                                                       ;93AD45;
@@ -5883,6 +5905,7 @@ ProjectileFlareSpritemaps_SuperMissile_7:
     db $02                                                               ;93AE46;
     dw $AA66                                                             ;93AE47;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93AE49:
     dw $0001,$01FC                                                       ;93AE49;
     db $FC                                                               ;93AE4D;
@@ -5902,6 +5925,7 @@ UNUSED_ProjectileFlareSpritemaps_93AE5E:
     dw $0001,$01FC                                                       ;93AE5E;
     db $FC                                                               ;93AE62;
     dw $3A3F                                                             ;93AE63;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Wave_IceWave_0:
     dw $0001,$01FC                                                       ;93AE65;
@@ -6546,6 +6570,7 @@ ProjectileFlareSpritemaps_ChargedWave_WaveSBA_19:
     db $EE                                                               ;93B365;
     dw $6C33                                                             ;93B366;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_ChargedWave_WaveSBA_93B368:
     dw $0004,$0000                                                       ;93B368;
     db $F8                                                               ;93B36C;
@@ -6567,6 +6592,7 @@ UNUSED_ProjectileFlareSpritemaps_ChargedWave_WaveSBA_93B37E:
     dw $AC33,$01F8                                                       ;93B38D;
     db $F8                                                               ;93B391;
     dw $2C33                                                             ;93B392;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_ChargedWave_WaveSBA_1A:
     dw $0008,$01F8                                                       ;93B394;
@@ -6720,6 +6746,7 @@ ProjectileFlareSpritemaps_ChargedWave_WaveSBA_21:
     db $F8                                                               ;93B4E1;
     dw $2C34                                                             ;93B4E2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_93B4E4:
     dw $0001,$01FC                                                       ;93B4E4;
     db $FC                                                               ;93B4E8;
@@ -6953,6 +6980,7 @@ UNUSED_ProjectileFlareSpritemaps_93B66B:
     dw $0001,$01FC                                                       ;93B66B;
     db $FC                                                               ;93B66F;
     dw $2C30                                                             ;93B670;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_ChargedIceWave_0:
     dw $0004,$0000                                                       ;93B672;
@@ -8380,6 +8408,7 @@ ProjectileFlareSpritemaps_Charged_PW_PIW_1D:
     db $F4                                                               ;93C2F1;
     dw $2C33                                                             ;93C2F2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_PW_PIW_93C2F4:
     dw $0004,$0008                                                       ;93C2F4;
     db $FC                                                               ;93C2F8;
@@ -8466,6 +8495,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_PW_PIW_93C388:
     dw $2C34,$01F0                                                       ;93C3AB;
     db $EC                                                               ;93C3AF;
     dw $2C34                                                             ;93C3B0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_PW_PIW_1E:
     dw $0007,$0014                                                       ;93C3B2;
@@ -8998,6 +9028,7 @@ ProjectileFlareSpritemaps_Charged_PW_PIW_27:
     db $08                                                               ;93C88C;
     dw $2C35                                                             ;93C88D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_PW_PIW_93C88F:
     dw $0004,$01FC                                                       ;93C88F;
     db $08                                                               ;93C893;
@@ -9084,6 +9115,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_PW_PIW_93C923:
     dw $2C37,$01ED                                                       ;93C946;
     db $F8                                                               ;93C94A;
     dw $2C37                                                             ;93C94B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_PW_PIW_28:
     dw $0007,$01FC                                                       ;93C94D;
@@ -9226,6 +9258,7 @@ ProjectileFlareSpritemaps_Charged_PW_PIW_2C:
     db $F4                                                               ;93CA8F;
     dw $2C37                                                             ;93CA90;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_PW_PIW_93CA92:
     dw $0008,$01F0                                                       ;93CA92;
     db $0C                                                               ;93CA96;
@@ -9384,6 +9417,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_PW_PIW_93CBB2:
     dw $6C35,$000C                                                       ;93CBFD;
     db $08                                                               ;93CC01;
     dw $6C35                                                             ;93CC02;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_PW_PIW_2D:
     dw $000C,$01E8                                                       ;93CC04;
@@ -10345,6 +10379,7 @@ ProjectileFlareSpritemaps_S_SI_SW_SIW_10:
     db $F4                                                               ;93D4B1;
     dw $AC31                                                             ;93D4B2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_S_SI_SW_SIW_93D4B4:
     dw $000C,$0009                                                       ;93D4B4;
     db $FA                                                               ;93D4B8;
@@ -10371,6 +10406,7 @@ UNUSED_ProjectileFlareSpritemaps_S_SI_SW_SIW_93D4B4:
     dw $AC32,$01F6                                                       ;93D4EB;
     db $00                                                               ;93D4EF;
     dw $AC31                                                             ;93D4F0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_S_SI_SW_SIW_11:
     dw $0004,$0006                                                       ;93D4F2;
@@ -13234,6 +13270,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_49:
     db $FC                                                               ;93EE22;
     dw $2C30                                                             ;93EE23;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EE25:
     dw $0003,$01F4                                                       ;93EE25;
     db $FC                                                               ;93EE29;
@@ -13253,6 +13290,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EE36:
     dw $2C30,$01F0                                                       ;93EE45;
     db $FC                                                               ;93EE49;
     dw $2C30                                                             ;93EE4A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_4A:
     dw $0002,$0002                                                       ;93EE4C;
@@ -13272,6 +13310,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_4B:
     db $F8                                                               ;93EE6B;
     dw $2C31                                                             ;93EE6C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EE6E:
     dw $0006,$000A                                                       ;93EE6E;
     db $04                                                               ;93EE72;
@@ -13286,6 +13325,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EE6E:
     dw $2C32,$01F2                                                       ;93EE87;
     db $F4                                                               ;93EE8B;
     dw $2C31                                                             ;93EE8C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_4C:
     dw $0001,$01FC                                                       ;93EE8E;
@@ -13299,6 +13339,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_4D:
     db $F8                                                               ;93EE9E;
     dw $2C33                                                             ;93EE9F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EEA1:
     dw $0003,$01FC                                                       ;93EEA1;
     db $F4                                                               ;93EEA5;
@@ -13318,6 +13359,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EEB2:
     dw $2C33,$01FC                                                       ;93EEC1;
     db $F8                                                               ;93EEC5;
     dw $2C33                                                             ;93EEC6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_4E:
     dw $0002,$01F6                                                       ;93EEC8;
@@ -13364,6 +13406,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_52:
     db $FC                                                               ;93EF1A;
     dw $6C30                                                             ;93EF1B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EF1D:
     dw $0003,$0004                                                       ;93EF1D;
     db $FC                                                               ;93EF21;
@@ -13383,6 +13426,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EF2E:
     dw $6C30,$0008                                                       ;93EF3D;
     db $FC                                                               ;93EF41;
     dw $6C30                                                             ;93EF42;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_53:
     dw $0002,$01F6                                                       ;93EF44;
@@ -13402,6 +13446,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_54:
     db $00                                                               ;93EF63;
     dw $EC31                                                             ;93EF64;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EF66:
     dw $0006,$01EE                                                       ;93EF66;
     db $F4                                                               ;93EF6A;
@@ -13416,6 +13461,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EF66:
     dw $EC32,$0006                                                       ;93EF7F;
     db $04                                                               ;93EF83;
     dw $EC31                                                             ;93EF84;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_55:
     dw $0001,$01FC                                                       ;93EF86;
@@ -13429,6 +13475,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_56:
     db $00                                                               ;93EF96;
     dw $AC33                                                             ;93EF97;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EF99:
     dw $0003,$01FC                                                       ;93EF99;
     db $04                                                               ;93EF9D;
@@ -13481,6 +13528,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93EFE2:
     dw $EC32,$0006                                                       ;93EFFB;
     db $04                                                               ;93EFFF;
     dw $EC31                                                             ;93F000;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_57:
     dw $0001,$01FC                                                       ;93F002;
@@ -13494,6 +13542,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_58:
     db $FC                                                               ;93F012;
     dw $2C34                                                             ;93F013;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F015:
     dw $0003,$01F4                                                       ;93F015;
     db $FC                                                               ;93F019;
@@ -13513,6 +13562,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F026:
     dw $2C34,$01F0                                                       ;93F035;
     db $FC                                                               ;93F039;
     dw $2C34                                                             ;93F03A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_59:
     dw $0002,$01FC                                                       ;93F03C;
@@ -13532,6 +13582,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_5A:
     db $FC                                                               ;93F05B;
     dw $2C35                                                             ;93F05C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F05E:
     dw $0006,$0004                                                       ;93F05E;
     db $08                                                               ;93F062;
@@ -13546,6 +13597,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F05E:
     dw $EC35,$01F4                                                       ;93F077;
     db $F8                                                               ;93F07B;
     dw $2C35                                                             ;93F07C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_5B:
     dw $0001,$01FC                                                       ;93F07E;
@@ -13559,6 +13611,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_5C:
     db $F8                                                               ;93F08E;
     dw $2C37                                                             ;93F08F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F091:
     dw $0003,$01FC                                                       ;93F091;
     db $04                                                               ;93F095;
@@ -13578,6 +13631,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F0A2:
     dw $2C37,$01FC                                                       ;93F0B1;
     db $F0                                                               ;93F0B5;
     dw $2C37                                                             ;93F0B6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_5D:
     dw $0002,$01FC                                                       ;93F0B8;
@@ -13597,6 +13651,7 @@ ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_5E:
     db $FC                                                               ;93F0D7;
     dw $6C35                                                             ;93F0D8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F0DA:
     dw $0006,$01F4                                                       ;93F0DA;
     db $08                                                               ;93F0DE;
@@ -13611,18 +13666,21 @@ UNUSED_ProjectileFlareSpritemaps_Charged_S_SI_SW_SIW_93F0DA:
     dw $AC35,$0004                                                       ;93F0F3;
     db $F8                                                               ;93F0F7;
     dw $6C35                                                             ;93F0F8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_0:
     dw $0001,$01FC                                                       ;93F0FA;
     db $FC                                                               ;93F0FE;
     dw $2C30                                                             ;93F0FF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F101:
     dw $0002,$01F8                                                       ;93F101;
     db $FC                                                               ;93F105;
     dw $2C30,$0000                                                       ;93F106;
     db $FC                                                               ;93F10A;
     dw $2C30                                                             ;93F10B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_1:
     dw $0003,$01F4                                                       ;93F10D;
@@ -13633,6 +13691,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_1:
     db $FC                                                               ;93F11B;
     dw $2C30                                                             ;93F11C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F11E:
     dw $0004,$01F0                                                       ;93F11E;
     db $FC                                                               ;93F122;
@@ -13656,6 +13715,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F134:
     dw $2C30,$01EC                                                       ;93F148;
     db $FC                                                               ;93F14C;
     dw $2C30                                                             ;93F14D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_2:
     dw $0006,$0010                                                       ;93F14F;
@@ -13694,12 +13754,14 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_4:
     db $FC                                                               ;93F198;
     dw $2C33                                                             ;93F199;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F19B:
     dw $0002,$01FC                                                       ;93F19B;
     db $00                                                               ;93F19F;
     dw $2C33,$01FC                                                       ;93F1A0;
     db $F8                                                               ;93F1A4;
     dw $2C33                                                             ;93F1A5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_5:
     dw $0003,$01FC                                                       ;93F1A7;
@@ -13710,6 +13772,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_5:
     db $F4                                                               ;93F1B5;
     dw $2C33                                                             ;93F1B6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F1B8:
     dw $0004,$01FC                                                       ;93F1B8;
     db $08                                                               ;93F1BC;
@@ -13733,6 +13796,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F1CE:
     dw $2C33,$01FC                                                       ;93F1E2;
     db $EC                                                               ;93F1E6;
     dw $2C33                                                             ;93F1E7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_6:
     dw $0006,$01FC                                                       ;93F1E9;
@@ -13784,6 +13848,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_9:
     db $F8                                                               ;93F24D;
     dw $2C31                                                             ;93F24E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F250:
     dw $0006,$0008                                                       ;93F250;
     db $04                                                               ;93F254;
@@ -13798,6 +13863,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F250:
     dw $2C32,$01F0                                                       ;93F269;
     db $F4                                                               ;93F26D;
     dw $2C31                                                             ;93F26E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_A:
     dw $0008,$000C                                                       ;93F270;
@@ -13859,6 +13925,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_D:
     db $F8                                                               ;93F2ED;
     dw $6C31                                                             ;93F2EE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F2F0:
     dw $0006,$01F0                                                       ;93F2F0;
     db $04                                                               ;93F2F4;
@@ -13873,6 +13940,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F2F0:
     dw $6C32,$0008                                                       ;93F309;
     db $F4                                                               ;93F30D;
     dw $6C31                                                             ;93F30E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_E:
     dw $0008,$01EC                                                       ;93F310;
@@ -13921,12 +13989,14 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_10:
     db $FC                                                               ;93F372;
     dw $2C34                                                             ;93F373;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F375:
     dw $0002,$0000                                                       ;93F375;
     db $FC                                                               ;93F379;
     dw $2C34,$01F8                                                       ;93F37A;
     db $FC                                                               ;93F37E;
     dw $2C34                                                             ;93F37F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_11:
     dw $0003,$0004                                                       ;93F381;
@@ -13937,6 +14007,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_11:
     db $FC                                                               ;93F38F;
     dw $2C34                                                             ;93F390;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F392:
     dw $0004,$0008                                                       ;93F392;
     db $FC                                                               ;93F396;
@@ -13960,6 +14031,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F3A8:
     dw $2C34,$01EC                                                       ;93F3BC;
     db $FC                                                               ;93F3C0;
     dw $2C34                                                             ;93F3C1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_12:
     dw $0006,$0010                                                       ;93F3C3;
@@ -13998,12 +14070,14 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_14:
     db $FC                                                               ;93F40C;
     dw $2C37                                                             ;93F40D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F40F:
     dw $0002,$01FC                                                       ;93F40F;
     db $00                                                               ;93F413;
     dw $2C37,$01FC                                                       ;93F414;
     db $F8                                                               ;93F418;
     dw $2C37                                                             ;93F419;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_15:
     dw $0003,$01FC                                                       ;93F41B;
@@ -14014,6 +14088,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_15:
     db $F4                                                               ;93F429;
     dw $2C37                                                             ;93F42A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F42C:
     dw $0004,$01FC                                                       ;93F42C;
     db $08                                                               ;93F430;
@@ -14037,6 +14112,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F442:
     dw $2C37,$01FC                                                       ;93F456;
     db $EC                                                               ;93F45A;
     dw $2C37                                                             ;93F45B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_16:
     dw $0006,$01FC                                                       ;93F45D;
@@ -14088,6 +14164,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_19:
     db $FC                                                               ;93F4C1;
     dw $2C35                                                             ;93F4C2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F4C4:
     dw $0006,$01FC                                                       ;93F4C4;
     db $F8                                                               ;93F4C8;
@@ -14102,6 +14179,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F4C4:
     dw $2C35,$01F4                                                       ;93F4DD;
     db $F8                                                               ;93F4E1;
     dw $2C35                                                             ;93F4E2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_1A:
     dw $0008,$0008                                                       ;93F4E4;
@@ -14163,6 +14241,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_1D:
     db $FC                                                               ;93F561;
     dw $6C35                                                             ;93F562;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F564:
     dw $0006,$01FC                                                       ;93F564;
     db $F8                                                               ;93F568;
@@ -14177,6 +14256,7 @@ UNUSED_ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_93F564:
     dw $6C35,$0004                                                       ;93F57D;
     db $F8                                                               ;93F581;
     dw $6C35                                                             ;93F582;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_1E:
     dw $0008,$01F0                                                       ;93F584;
@@ -14220,6 +14300,7 @@ ProjectileFlareSpritemaps_Charged_P_PI_PW_PIW_1F:
     db $F0                                                               ;93F5DF;
     dw $6C35                                                             ;93F5E0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DrawShinesparkWindupEffectSprite_93F5E2:
     PHP                                                                  ;93F5E2;
     PHB                                                                  ;93F5E3;
@@ -14253,6 +14334,7 @@ UNUSED_DrawShinesparkWindupEffectSprite_93F5E2:
     PLB                                                                  ;93F61A;
     PLP                                                                  ;93F61B;
     RTL                                                                  ;93F61C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Freespace_Bank93_F61D:                                                   ;93F61D;

--- a/src/bank_94.asm
+++ b/src/bank_94.asm
@@ -901,6 +901,7 @@ SamusBlockCollisionDetection_Horizontal_Slope_NonSquare:
     dw $00F0,$0600,$00F0,$0600,$00F0,$4000,$0080,$4000                   ;9485E8;
     dw $0080,$6000,$0050,$6000,$0050,$6000,$0050                         ;9485F8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_948606:
     LDA.W $0DC4                                                          ;948606;
     STA.W $4204                                                          ;948609;
@@ -1053,6 +1054,7 @@ UNUSED_948606:
 
 ..gotoSolidShootableGrapple:
     JMP.W SamusBlockCollisionReaction_Horizontal_SolidShootableGrapple   ;9486FB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 SamusBlockCollisionReaction_Vertical_Slope_NonSquare:
@@ -1356,8 +1358,10 @@ Align_SamusYPosition_WithNonSquareSlope:
     RTL                                                                  ;94891A;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SlopeDefinitions_94891B:
     db $0F,$0E,$0D,$0C,$0B,$0A,$09,$08,$07,$06,$05,$04,$03,$02,$01,$00   ;94891B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SlopeDefinitions_SlopeLeftXOffsetByYPixel:
     db $10,$10,$10,$10,$10,$10,$10,$10,$00,$00,$00,$00,$00,$00,$00,$00   ;94892B;
@@ -1616,6 +1620,7 @@ SquareSlopeDefinitions_Bank94:
     db $00,$00,$80,$80,$00,$80,$00,$80,$00,$00,$00,$80,$00,$80,$80,$80   ;948E54;
     db $80,$80,$80,$80                                                   ;948E64;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DetermineSamusSuitPaletteIndex_948E68:
     LDY.W #$0004                                                         ;948E68;
     LDA.W $09A2                                                          ;948E6B;
@@ -1630,6 +1635,7 @@ UNUSED_DetermineSamusSuitPaletteIndex_948E68:
 
 .return:
     RTS                                                                  ;948E7C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CLCRTS_948E7D:
@@ -3136,6 +3142,7 @@ CLCRTS_9497D8:
     RTS                                                                  ;9497F1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SomeKindOfUpwardsBoost_9497F2:
     LDA.W $0B36                                                          ;9497F2;
     CMP.W #$0001                                                         ;9497F5;
@@ -3153,6 +3160,7 @@ UNUSED_SomeKindOfUpwardsBoost_9497F2:
     STZ.W $0B2C                                                          ;94980B;
     CLC                                                                  ;94980E;
     RTS                                                                  ;94980F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CLCRTS_949810:

--- a/src/bank_9B.asm
+++ b/src/bank_9B.asm
@@ -13,6 +13,7 @@ SamusPalettes_DeathSequence_YellowFlash:
     dw $03FF,$03FF,$03FF,$03FF,$03FF,$03FF,$03FF,$03FF                   ;9B9420;
     dw $03FF,$03FF,$03FF,$03FF,$03FF,$03FF,$03FF,$03FF                   ;9B9430;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusPalettes_9B9440:
     dw $3800,$02FF,$0217,$0150,$0089,$00BB,$3A9F,$2A19                   ;9B9440;
     dw $1DB4,$114F,$090B,$3BE0,$033F,$021B,$010E,$0074                   ;9B9450;
@@ -40,11 +41,13 @@ UNUSED_SamusPalettes_9B94E0:
 UNUSED_SamusPalettes_9B9500:
     dw $3800,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF                   ;9B9500;
     dw $7FFF,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF,$7FFF                   ;9B9510;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusPalettes_VariaSuit:
     dw $0000,$0108,$02FF,$1405,$3BE0,$21A8,$579F,$4AD2                   ;9B9520;
     dw $3A4E,$00BB,$01BE,$008E,$0252,$1104,$0074,$000D                   ;9B9530;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusPalettes_9B9540:
     dw $14E0,$00CE,$421F,$1405,$3BE0,$21A8,$579F,$4AD2                   ;9B9540;
     dw $3A4E,$00BB,$5914,$30AA,$0216,$1104,$0074,$000D                   ;9B9550;
@@ -92,6 +95,7 @@ UNUSED_SamusPalettes_9B9680:
 UNUSED_SamusPalettes_9B96A0:
     dw $3800,$2BEE,$6BFF,$3FC5,$63E0,$4BE8,$7FFF,$73F2                   ;9B96A0;
     dw $63EE,$2BFB,$7FF4,$5BEA,$2BF6,$3BE4,$2BF4,$2BED                   ;9B96B0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusPalettes_CrystalFlash_0:
     dw $3800,$4210,$4210,$4210,$4210,$4210,$4210,$4210                   ;9B96C0;
@@ -135,6 +139,7 @@ SamusPalettes_CrystalFlash_5:
 SamusPalettes_CrystalFlash_5_bubble:
     dw $7FFF,$77BF,$6F7F,$6B5F,$673F,$7FFF                               ;9B9774;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusPalettes_9B9780:
     dw $0000,$00CE,$421F,$1405,$3BE0,$21A8,$579F,$4AD2                   ;9B9780;
     dw $3A4E,$00BB,$5914,$30AA,$0216,$1104,$0074,$000D                   ;9B9790;
@@ -150,6 +155,7 @@ UNUSED_SamusPalettes_9B97C0:
 UNUSED_SamusPalettes_9B97E0:
     dw $0000,$42DE,$7FFF,$5615,$7BF0,$63B8,$7FFF,$7FFF                   ;9B97E0;
     dw $7BFE,$42BF,$7F1F,$72BA,$43FF,$5314,$427F,$421D                   ;9B97F0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SamusPalettes_GravitySuit:
     dw $3800,$0108,$421F,$1405,$3BE0,$21A8,$579F,$4AD2                   ;9B9800;
@@ -2111,6 +2117,7 @@ HandleConnectingGrapple_Crouching_AimingLeft:
     BRA HandleConnectingGrapple_StuckInPlace                             ;9BBA2F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HandleConnectingGrapple_InAir_AimingRight_9BBA31:
     LDA.W #$00AC                                                         ;9BBA31;
     STA.W $0A2A                                                          ;9BBA34;
@@ -2145,6 +2152,7 @@ UNUSED_HandleConnectingGrapple_InAir_AimingLeft_9BBA59:
     LDA.W #$00AD                                                         ;9BBA59;
     STA.W $0A2A                                                          ;9BBA5C;
     BRA HandleConnectingGrapple_StuckInPlace                             ;9BBA5F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 HandleConnectingGrapple_Swinging:
@@ -3089,8 +3097,10 @@ GrappleBeamFireVelocityTable_Y:
     dw $F40C,$F784,$0000,$087C,$0BF4,$0BF4,$087C,$0000                   ;9BC0EF;
     dw $F784,$F40C                                                       ;9BC0FF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_9BC103:
     db $80                                                               ;9BC103;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 GrappleBeamFireAngles:
     dw $8000,$A000,$C000,$E000,$0000,$0000,$2000,$4000                   ;9BC104;
@@ -3346,8 +3356,10 @@ GrappleBeamSpecialAngles_grappleFunction:
     dw $8D80,$00B9,$0008,$0010                                           ;9BC484;
     dw GrappleBeamFunction_WallGrab                                      ;9BC48C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_9BC48E:
     db $20,$3A                                                           ;9BC48E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 GrappleBeamHandler:
     PHP                                                                  ;9BC490;
@@ -3658,9 +3670,11 @@ facingLeft:
     RTS                                                                  ;9BC700;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CLCRTS_9B7C01:
     CLC                                                                  ;9BC701;
     RTS                                                                  ;9BC702;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 GrappleBeamFunction_Firing:

--- a/src/bank_9E.asm
+++ b/src/bank_9E.asm
@@ -287,6 +287,7 @@ incbin "../data/SamusTiles_Top_Set2_Entry1F.bin" ; $100 bytes
 UNUSED_SamusTiles_Bottom_Set3_Entry0_9EE9C0:
 incbin "../data/UNUSED_SamusTiles_Bottom_Set3_Entry0_9EE9C0.bin" ; $80 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SamusTiles_Bottom_Set3_Entry1_9EEA40:
 incbin "../data/UNUSED_SamusTiles_Bottom_Set3_Entry1_9EEA40.bin" ; $100 bytes
 
@@ -334,6 +335,7 @@ incbin "../data/UNUSED_SamusTiles_Bottom_Set3_EntryF_9EF4C0.bin" ; $100 bytes
 
 UNUSED_SamusTiles_Bottom_Set3_Entry10_9EF5C0:
 incbin "../data/UNUSED_SamusTiles_Bottom_Set3_Entry10_9EF5C0.bin" ; $100 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Freespace_Bank9E_F6C0:                                                   ;9EF6C0;
 ; $940 bytes

--- a/src/bank_A0.asm
+++ b/src/bank_A0.asm
@@ -169,6 +169,7 @@ Instruction_Common_CallFunctionInY_WithA:
     RTL                                                                  ;A080B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_Common_CallExternalFunctionInY_A080B5:
     LDA.W $0000,Y                                                        ;A080B5;
     STA.B $12                                                            ;A080B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_Common_CallExternalFunctionInY_WithA_A080CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A080EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_Common_GotoY:
@@ -1188,6 +1190,7 @@ TransferEnemyTilesToVRAM_InitialiseEnemies:
     RTL                                                                  ;A08D39;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LoadEnemyWidthHeightHealthLayerBank_A08D3A:
     PHX                                                                  ;A08D3A;
     PHY                                                                  ;A08D3B;
@@ -1207,6 +1210,7 @@ UNUSED_LoadEnemyWidthHeightHealthLayerBank_A08D3A:
     PLY                                                                  ;A08D61;
     PLX                                                                  ;A08D62;
     RTL                                                                  ;A08D63;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 ProcessEnemySet_LoadPalettesAndEnemyLoadingData:
@@ -1735,6 +1739,7 @@ DecrementSamusHurtTimers_ClearActiveEnemyIndicesLists:
     RTL                                                                  ;A0918A;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LoggingRoutineForASpecificVertcalEnemyReaction_A0918B:
     PHB                                                                  ;A0918B;
     LDA.W $1848                                                          ;A0918C;
@@ -1783,6 +1788,7 @@ UNUSED_LoggingRoutineForASpecificVertcalEnemyReaction_A0918B:
     STA.W $1848                                                          ;A09209;
     PLB                                                                  ;A0920C;
     RTS                                                                  ;A0920D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Spawn_Enemy_Drops:
@@ -2255,6 +2261,7 @@ NormalEnemyFrozenAI:
     RTL                                                                  ;A095AC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExecuteEnemyAI_A095AD:
     PHB                                                                  ;A095AD;
     PHP                                                                  ;A095AE;
@@ -2385,6 +2392,7 @@ UNUSED_RespawnEnemy_A095F1:
     PLB                                                                  ;A096C5;
     PLB                                                                  ;A096C6;
     JML.W [$1784]                                                        ;A096C7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 ProcessExtendedTilemap:
@@ -5281,6 +5289,7 @@ Samus_vs_SolidEnemy_CollisionDetection:
     JMP.W .next                                                          ;A0AB81;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 .unused:
     PHA                                                                  ;A0AB84;
     LDX.W $18A6                                                          ;A0AB85;
@@ -5327,6 +5336,7 @@ Samus_vs_SolidEnemy_CollisionDetection:
     PLB                                                                  ;A0ABE4;
     PLP                                                                  ;A0ABE5;
     RTL                                                                  ;A0ABE6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckIfEnemyIsTouchingSamusFromBelow:
@@ -5372,6 +5382,7 @@ CheckIfEnemyIsTouchingSamusFromBelow:
     RTL                                                                  ;A0AC28;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CheckIfEnemyIsTouchingSamusFromAbove_A0AC29:
     LDA.W $0AF6                                                          ;A0AC29;
     SEC                                                                  ;A0AC2C;
@@ -5411,6 +5422,7 @@ UNUSED_CheckIfEnemyIsTouchingSamusFromAbove_A0AC29:
 .touching:
     LDA.W #$FFFF                                                         ;A0AC63;
     RTL                                                                  ;A0AC66;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckIfEnemyIsTouchingSamus:
@@ -5525,6 +5537,7 @@ CalculateDistanceAndAngleOfSamusFromEnemy:
     RTL                                                                  ;A0AD32;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyVariable_ZeroOrMax_A0AD33:
     PHB                                                                  ;A0AD33;
     SEP #$20                                                             ;A0AD34;
@@ -5574,6 +5587,7 @@ UNUSED_NegateA_A0AD62:
     EOR.W #$FFFF                                                         ;A0AD6B;
     INC A                                                                ;A0AD6E;
     RTL                                                                  ;A0AD6F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckIfEnemyCenterIsOnScreen:
@@ -5727,6 +5741,7 @@ notAboveOrBelow:
     RTL                                                                  ;A0AE7B;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProtoInstructionListHandler_A0AE7C:
     LDX.W $0E54                                                          ;A0AE7C;
     LDA.W $0F78,X                                                        ;A0AE7F;
@@ -5781,6 +5796,7 @@ UNUSED_ProtoInstructionListHandler_A0AE7C:
 .return1:
     LDA.W #$0001                                                         ;A0AED9;
     RTL                                                                  ;A0AEDC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Get_SamusY_minus_EnemyY:
@@ -5833,6 +5849,7 @@ IsSamusWithinAPixelColumnsOfEnemy:
     RTL                                                                  ;A0AF28;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveEnemyX_NoCollision_A0AF29:
     LDA.W $0F7C,X                                                        ;A0AF29;
     CLC                                                                  ;A0AF2C;
@@ -5866,6 +5883,7 @@ UNUSED_MoveEnemy_12_14_A0AF4D:
     dw MoveEnemyX_plus_12_14                                             ;A0AF54;
     dw MoveEnemyY_minus_12_14                                            ;A0AF56;
     dw MoveEnemyY_plus_12_14                                             ;A0AF58;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 MoveEnemyX_minus_12_14:
     LDA.W $0F7C,X                                                        ;A0AF5A;
@@ -5911,6 +5929,7 @@ MoveEnemyY_plus_12_14:
     RTL                                                                  ;A0AFA1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveSamus_ExtraXDisplacement_minus_12_14_A0AFA2:
     LDA.W $0AF8                                                          ;A0AFA2;
     SEC                                                                  ;A0AFA5;
@@ -5953,6 +5972,7 @@ UNUSED_MoveSamus_ExtraYDisplacement_plus_12_14_A0AFD8:
     ADC.B $14                                                            ;A0AFE4;
     STA.W $0B5C                                                          ;A0AFE6;
     RTL                                                                  ;A0AFE9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Sign_Extend_A:
@@ -5968,12 +5988,14 @@ Sign_Extend_A:
     RTL                                                                  ;A0AFFC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MultiplyBy10_A0AFFD:
     ASL A                                                                ;A0AFFD;
     ASL A                                                                ;A0AFFE;
     ASL A                                                                ;A0AFFF;
     ASL A                                                                ;A0B000;
     RTL                                                                  ;A0B001;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MultiplyBy20_A0B002:
@@ -5985,6 +6007,7 @@ MultiplyBy20_A0B002:
     RTL                                                                  ;A0B007;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MultiplyBy30_A0B008:
     ASL A                                                                ;A0B008;
     ASL A                                                                ;A0B009;
@@ -6053,6 +6076,7 @@ UNUSED_XBA_A0B060:
     XBA                                                                  ;A0B063;
     REP #$20                                                             ;A0B064;
     RTL                                                                  ;A0B066;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 NegateA_A0B067:
@@ -6090,6 +6114,7 @@ GetSignedYMinusX_A0B07D:
     RTL                                                                  ;A0B09F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GetNegativeA_A0B0A0:
     EOR.W #$FFFF                                                         ;A0B0A0;
     INC A                                                                ;A0B0A3;
@@ -6105,6 +6130,7 @@ UNUSED_SignedA_ZeroCountsAsPositive_A0B0A5:
 
   + LDA.W #$0001                                                         ;A0B0AE;
     RTL                                                                  ;A0B0B1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EightBitCosineMultiplication_A0B0B2:
@@ -6979,6 +7005,7 @@ CheckIfXDistanceBetweenEnemyAndSamusIsAtLeastA:
     RTL                                                                  ;A0BBAC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CheckIfYDistanceBetweenEnemyAndSamusIsAtLeastA_A0BBAD:
     PHA                                                                  ;A0BBAD;
     LDA.W $0AFA                                                          ;A0BBAE;
@@ -6991,6 +7018,7 @@ UNUSED_CheckIfYDistanceBetweenEnemyAndSamusIsAtLeastA_A0BBAD:
   + CMP.B $01,S                                                          ;A0BBBB;
     PLA                                                                  ;A0BBBD;
     RTL                                                                  ;A0BBBE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckForHorizontalSolidBlockCollision:
@@ -7225,6 +7253,7 @@ CheckForVerticalSolidBlockCollision:
     RTL                                                                  ;A0BD25;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveEnemyRight_NoBlockCollisionReactions_A0BD26:
     PHB                                                                  ;A0BD26;
     SEP #$20                                                             ;A0BD27;
@@ -7611,6 +7640,7 @@ UNUSED_CheckForHorizontalSolidBlockCollision_A0BEBF:
     SEC                                                                  ;A0BF87;
     PLB                                                                  ;A0BF88;
     RTL                                                                  ;A0BF89;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckForVerticalSolidBlockCollision_SkreeMetaree:
@@ -7765,6 +7795,7 @@ CalculateAngleOfSamusFromEnemy:
     JMP.W CalculateAngleOfXYOffset                                       ;A0C07B;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CalculateAngleOfEnemyYFromEnemyX_A0C07E:
     PHP                                                                  ;A0C07E;
     REP #$30                                                             ;A0C07F;
@@ -7777,6 +7808,7 @@ UNUSED_CalculateAngleOfEnemyYFromEnemyX_A0C07E:
     SBC.W $0F7E,X                                                        ;A0C08E;
     STA.B $14                                                            ;A0C091;
     JMP.W CalculateAngleOfXYOffset                                       ;A0C093;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CalculateAngleOfEnemyYFromEnemyX:
@@ -7978,6 +8010,7 @@ CheckIfEnemyIsHorizontallyOffScreen:
     RTL                                                                  ;A0C1B0;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CheckIfEnemyIsVerticallyOffScreen_A0C1B1:
     LDA.W $0F7E,X                                                        ;A0C1B1;
     BMI .offScreen                                                       ;A0C1B4;
@@ -8085,6 +8118,7 @@ UNUSED_AssessSamusThreatLevel_A0C1D4:
 
 .return:
     RTL                                                                  ;A0C269;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 ProcessEnemyInstructions:
@@ -8437,8 +8471,10 @@ EnemyBlockCollisionReaction_Horizontal_Slope_NonSquare:
     RTS                                                                  ;A0C49E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 .unused:
     dw $0000                                                             ;A0C49F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 .adjustedDistanceMult:
     dw $0100,$0000,$0100,$0000,$0100,$0000,$0100,$0000                   ;A0C4A1;
@@ -8825,6 +8861,7 @@ MoveEnemyRightBy_14_12_Common:
     RTL                                                                  ;A0C777;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveEnemyDownBy_14_12_A0C778:
     LDA.W #$4000                                                         ;A0C778;
     STA.B $20                                                            ;A0C77B;
@@ -8835,6 +8872,7 @@ UNUSED_MoveEnemyDownBy_14_12_A0C77F:
     LDA.W #$8000                                                         ;A0C77F;
     STA.B $20                                                            ;A0C782;
     BRA MoveEnemyDownBy_14_12_BranchEntry                                ;A0C784;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MoveEnemyDownBy_14_12:
@@ -9175,6 +9213,7 @@ AlignEnemyYPositionWIthNonSquareSlope:
     RTL                                                                  ;A0C9BE;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CommonEnemyProjectileSpeeds_LinearlyIncreasing_A0C9BF:
     dw $0000,$0000,$0000,$0000,$0000,$1000,$FFFF,$F000                   ;A0C9BF;
     dw $0000,$2000,$FFFF,$E000,$0000,$3000,$FFFF,$D000                   ;A0C9CF;
@@ -9209,6 +9248,7 @@ UNUSED_CommonEnemyProjectileSpeeds_LinearlyIncreasing_A0C9BF:
     dw $0003,$C000,$FFFC,$4000,$0003,$D000,$FFFC,$3000                   ;A0CB9F;
     dw $0003,$E000,$FFFC,$2000,$0003,$F000,$FFFC,$1000                   ;A0CBAF;
     dw $0004,$0000,$FFFC,$0000                                           ;A0CBBF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 CommonEnemyProjectileSpeeds_QuadraticallyIncreasing:
     dw $0000,$0000,$0000,$0000,$0109,$0000,$FEF7,$FFFF                   ;A0CBC7;
@@ -12973,9 +13013,11 @@ EnemyHeaders_Chozo:
     dw EnemyVulnerabilities_Indestructible                               ;A0F13B;
     dw $0000                                                             ;A0F13D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_BunchOf2s_A0F13F:
     dw $0202,$0202,$0202,$0202,$0202,$0202,$0202,$0202                   ;A0F13F;
     dw $0202,$0202                                                       ;A0F14F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_EnemyHeaders_SpinningTurtleEye_A0F153:
     dw $0200                                                             ;A0F153;

--- a/src/bank_A1.asm
+++ b/src/bank_A1.asm
@@ -224,9 +224,11 @@ EnemyPopulations_CrateriaMap:
     dw $FFFF                                                             ;A185A9;
     db $00                                                               ;A185AB;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A185AC:
     dw $FFFF                                                             ;A185AC;
     db $00                                                               ;A185AE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_FinalMissile_1:
     dw $FFFF                                                             ;A185AF;
@@ -239,9 +241,11 @@ EnemyPopulations_Climb_2:
     dw $00C0,$0880,$0000,$2800,$0004,$0000,$0000,$FFFF                   ;A185C4;
     db $02                                                               ;A185D4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A185D5:
     dw $FFFF                                                             ;A185D5;
     db $00                                                               ;A185D7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_CrateriaSave:
     dw $FFFF                                                             ;A185D8;
@@ -295,9 +299,11 @@ EnemyPopulations_WestOcean:
     dw $0370,$0160,$0000,$A000,$0000,$0001,$0010,$FFFF                   ;A186E6;
     db $07                                                               ;A186F6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A186F7:
     dw $FFFF                                                             ;A186F7;
     db $00                                                               ;A186F9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_Parlor_0:
     dw EnemyHeaders_Sbug                                                 ;A186FA;
@@ -362,9 +368,11 @@ EnemyPopulations_CrateriaSuper:
     dw $02B8,$07A8,$0000,$2000,$0000,$0103,$0020,$FFFF                   ;A188A2;
     db $00                                                               ;A188B2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A188B3:
     dw $FFFF                                                             ;A188B3;
     db $00                                                               ;A188B5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_PreBowling:
     dw EnemyHeaders_HZoomer                                              ;A188B6;
@@ -953,9 +961,11 @@ EnemyPopulations_RedBrinstarSave:
     dw $FFFF                                                             ;A19669;
     db $00                                                               ;A1966B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A1966C:
     dw $FFFF                                                             ;A1966C;
     db $00                                                               ;A1966E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_BlueBrinstarETank_0:
     dw EnemyHeaders_Eye                                                  ;A1966F;
@@ -1049,10 +1059,12 @@ EnemyPopulations_WarehouseETank:
     dw $0060,$0098,$0000,$2000,$0000,$0000,$0000,$FFFF                   ;A198C0;
     db $04                                                               ;A198D0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A198D1:
     dw EnemyHeaders_Elevator                                             ;A198D1;
     dw $0080,$00A0,$0000,$2C00,$0000,$0000,$0140,$FFFF                   ;A198D3;
     db $00                                                               ;A198E3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_WarehouseEntrance:
     dw EnemyHeaders_Elevator                                             ;A198E4;
@@ -1853,9 +1865,11 @@ EnemyPopulations_MagdolliteTunnel:
     dw $023C,$005D,$0000,$2000,$0000,$0030,$0002,$FFFF                   ;A1ACF5;
     db $03                                                               ;A1AD05;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_8FB3EE_A1AD06:
     dw $FFFF                                                             ;A1AD06;
     db $00                                                               ;A1AD08;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_LavaDive:
     dw EnemyHeaders_Namihe                                               ;A1AD09;
@@ -4148,6 +4162,7 @@ EnemyPopulations_TourianRecharge:
     dw $FFFF                                                             ;A1E70B;
     db $00                                                               ;A1E70D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyPopulations_A1E70E:
     dw EnemyHeaders_CorpseZoomer                                         ;A1E70E;
     dw $00F0,$0040,$0000,$A000,$0000,$0000,$0000                         ;A1E710;
@@ -4166,6 +4181,7 @@ UNUSED_EnemyPopulations_A1E70E:
     dw EnemyHeaders_CorpseSkree                                          ;A1E77E;
     dw $0180,$0047,$0000,$A000,$0000,$0004,$0000,$FFFF                   ;A1E780;
     db $00                                                               ;A1E790;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyPopulations_UpperTourianSave:
     dw $FFFF                                                             ;A1E791;

--- a/src/bank_A2.asm
+++ b/src/bank_A2.asm
@@ -169,6 +169,7 @@ Instruction_CommonA2_CallFunctionInY_WithA:
     RTL                                                                  ;A280B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA2_CallExternalFunctionInY_A280B5:
     LDA.W $0000,Y                                                        ;A280B5;
     STA.B $12                                                            ;A280B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA2_CallExternalFunctionInY_WithA_A280CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A280EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA2_GotoY:
@@ -742,10 +744,12 @@ Spritemap_Boyon_6:
     db $F8                                                               ;A28908;
     dw $210C                                                             ;A28909;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Boyon_A2890B:
     dw $0001,$C3F8                                                       ;A2890B;
     db $F8                                                               ;A2890F;
     dw $210E                                                             ;A28910;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Stoke:
     dw $3800,$3DB3,$292E,$1486,$1840,$3D92,$38CA,$1C61                   ;A28912;
@@ -1146,6 +1150,7 @@ InstList_BabyTurtle_Spinning:
     dw Instruction_Common_GotoY                                          ;A28BEA;
     dw InstList_BabyTurtle_Spinning                                      ;A28BEC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_A28BEE:
     dw $0010                                                             ;A28BEE;
     dw Spritemap_MamaTurtle_FacingLeft_3                                 ;A28BF0;
@@ -1157,6 +1162,7 @@ UNUSED_InstList_A28BEE:
     dw Spritemap_MamaTurtle_FacingLeft_6                                 ;A28BFC;
     dw Instruction_Common_GotoY                                          ;A28BFE;
     dw UNUSED_InstList_A28BEE                                            ;A28C00;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_MamaTurtle_Spinning:
     dw $0001                                                             ;A28C02;
@@ -1269,6 +1275,7 @@ InstList_BabyTurtle_CrawlingRight:
     dw Spritemap_BabyTurtle_FacingRight_11                               ;A28CC0;
     dw Instruction_BabyTurtle_LoopOrTurnAroundIfMovedTooFar              ;A28CC2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_A28CC4:
     dw $0005                                                             ;A28CC4;
     dw Spritemap_BabyTurtle_FacingRight_12                               ;A28CC6;
@@ -1304,6 +1311,7 @@ UNUSED_InstList_A28CEC:
     dw Spritemap_MamaTurtle_FacingRight_11                               ;A28CFA;
     dw Instruction_CommonA2_GotoY                                        ;A28CFC;
     dw UNUSED_InstList_A28CEC                                            ;A28CFE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_MamaTurtle_FacingRight_EnterShell:
     dw $0001                                                             ;A28D00;
@@ -1949,6 +1957,7 @@ Function_BabyTurtle_Spinning_Unstoppable:
     RTL                                                                  ;A2921C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_A2921D:
     LDY.W #InstList_BabyTurtle_CrawlingLeft                              ;A2921D;
     LDA.W $0FB0,X                                                        ;A29220;
@@ -1963,6 +1972,7 @@ UNUSED_A2921D:
     LDA.W #Function_BabyTurtle_Crawling_NotCarryingSamus                 ;A29232;
     STA.W $0FA8,X                                                        ;A29235;
     RTL                                                                  ;A29238;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_BabyTurtle_Spinning_Stoppable:
@@ -2616,6 +2626,7 @@ Spritemap_MamaTurtle_FacingLeft_8:
     db $F0                                                               ;A296FC;
     dw $210C                                                             ;A296FD;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_MamaTurtle_FacingLeft_A296FF:
     dw $000A,$0000                                                       ;A296FF;
     db $08                                                               ;A29703;
@@ -2638,6 +2649,7 @@ UNUSED_Spritemap_MamaTurtle_FacingLeft_A296FF:
     dw $610C,$C3F0                                                       ;A2972C;
     db $EA                                                               ;A29730;
     dw $210C                                                             ;A29731;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_BabyTurtle_FacingRight_B:
     dw $0001,$C3F8                                                       ;A29733;
@@ -2903,6 +2915,7 @@ Spritemap_MamaTurtle_FacingRight_11:
     db $F0                                                               ;A29956;
     dw $610C                                                             ;A29957;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_MamaTurtle_FacingRight_A29959:
     dw $000A,$01F8                                                       ;A29959;
     db $08                                                               ;A2995D;
@@ -2925,6 +2938,7 @@ UNUSED_Spritemap_MamaTurtle_FacingRight_A29959:
     dw $210C,$C200                                                       ;A29986;
     db $EA                                                               ;A2998A;
     dw $610C                                                             ;A2998B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Puyo:
     dw $3800,$4B9C,$2610,$0CC6,$0C63,$42F7,$2A52,$19AD                   ;A2998D;
@@ -4813,6 +4827,7 @@ RTL_A2A7D7:
     RTL                                                                  ;A2A7D7;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Function_Ship_RiseToYPosition80_Descend:
     LDA.W $0AFA                                                          ;A2A7D8;
     SEC                                                                  ;A2A7DB;
@@ -4837,6 +4852,7 @@ UNUSED_Function_Ship_RiseToYPosition80_Descend:
 
 .return:
     RTL                                                                  ;A2A80B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_Ship_LandingOnZebes_Descending:
@@ -5810,12 +5826,14 @@ InstList_Mellow_Mella_Menu:
     dw Instruction_Common_GotoY                                          ;A2B023;
     dw InstList_Mellow_Mella_Menu                                        ;A2B025;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_OldMovementData_A2B027:
     dw $0002,$FFFC,$FFFE,$0004,$0002,$FFFE,$0002,$0004                   ;A2B027;
     dw $0002,$FFFE,$FFFE,$0002,$FFFC,$FFFE,$0002,$0002                   ;A2B037;
     dw $FFFE,$FFFE,$0004,$0002,$FFFC,$FFFE,$0002,$FFFE                   ;A2B047;
     dw $FFFC,$FFFE,$0002,$0002,$FFFE,$0004,$0002,$FFFE                   ;A2B057;
     dw $FFFE,$0002                                                       ;A2B067;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_Mellow_Mella_Menu:
     LDX.W $0E54                                                          ;A2B06B;
@@ -6174,6 +6192,7 @@ InstList_Multiviola:
     dw Instruction_Common_GotoY                                          ;A2B314;
     dw InstList_Multiviola                                               ;A2B316;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Multiviola_A2B318:
     dw $0002                                                             ;A2B318;
     dw UNUSED_Spritemap_Multiviola_A2B4E2                                ;A2B31A;
@@ -6277,6 +6296,7 @@ UNUSED_InstList_Multiviola_A2B37C:
     dw Spritemap_Common_Nothing                                          ;A2B3DA;
     dw Instruction_Common_GotoY                                          ;A2B3DC;
     dw UNUSED_InstList_Multiviola_A2B37C                                 ;A2B3DE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_Multiviola:
     LDX.W $0E54                                                          ;A2B3E0;
@@ -6408,6 +6428,7 @@ Spritemap_Multiviola_7:
     db $F8                                                               ;A2B4DF;
     dw $210E                                                             ;A2B4E0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Multiviola_A2B4E2:
     dw $0001,$81F8                                                       ;A2B4E2;
     db $F8                                                               ;A2B4E6;
@@ -6447,6 +6468,7 @@ UNUSED_Spritemap_Multiviola_A2B513:
     dw $0001,$81F8                                                       ;A2B513;
     db $F8                                                               ;A2B517;
     dw $212E                                                             ;A2B518;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Polyp:
     dw $0001                                                             ;A2B51A;
@@ -6883,6 +6905,7 @@ DecrementRinkaCounter:
     RTS                                                                  ;A2B89B;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Rinka_A2B89C:
     LDA.W $0E44                                                          ;A2B89C;
     AND.W #$0003                                                         ;A2B89F;
@@ -6899,6 +6922,7 @@ UNUSED_Rinka_A2B89C:
     ORA.W #$0400                                                         ;A2B8B4;
     STA.W $0F86,X                                                        ;A2B8B7;
     RTS                                                                  ;A2B8BA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MarkRinkaSpawnPointAvailable:
@@ -7044,6 +7068,7 @@ ContactReaction_Rinka_Common:
     RTL                                                                  ;A2B9A1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_Rinka_GotoYIfCounterGreaterThan2_A2B9A2:
     LDA.L $7E783C                                                        ;A2B9A2;
     CMP.W #$0003                                                         ;A2B9A6;
@@ -7057,6 +7082,7 @@ UNUSED_Instruction_Rinka_GotoYIfCounterGreaterThan2_A2B9A2:
     LDA.W $0000,Y                                                        ;A2B9AE;
     TAY                                                                  ;A2B9B1;
     RTL                                                                  ;A2B9B2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_Rinka_SetAsIntangibleAndInvisible:
@@ -7170,6 +7196,7 @@ Palette_Rio:
     dw $3800,$2FFF,$1AF7,$014A,$0063,$275A,$0EB5,$0210                   ;A2BA7B;
     dw $01CE,$03E0,$02E0,$0200,$0100,$7F00,$6DE0,$54E0                   ;A2BA8B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Rio_Idle_A2BB9B:
     dw $0004                                                             ;A2BA9B;
     dw Spritemap_Rio_0                                                   ;A2BA9D;
@@ -7261,6 +7288,7 @@ UNUSED_InstList_Rio_Swooping_A2BACF:
     dw Spritemap_Rio_7                                                   ;A2BB45;
     dw Instruction_Common_GotoY                                          ;A2BB47;
     dw UNUSED_InstList_Rio_Swooping_A2BACF                               ;A2BB49;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Rio_Idle:
     dw $0004                                                             ;A2BB4B;
@@ -7331,14 +7359,18 @@ InstList_Rio_SwoopCooldown:
 RioConstants_YVelocity:
     dw $0580                                                             ;A2BBBB;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RioConstants_A2BBBD:
     dw $0600                                                             ;A2BBBD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RioConstants_XVelocity:
     dw $0180                                                             ;A2BBBF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RioConstants_A2BBC1:
     dw $0200                                                             ;A2BBC1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_Rio_SetAnimationFinishedFlag:
     LDX.W $0E54                                                          ;A2BBC3;
@@ -8144,8 +8176,10 @@ GerutaConstants_swoopYSpeeds:
 GerutaConstants_swoopXSpeed:
     dw $0100                                                             ;A2C1C5;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GerutaConstants_maybeLeftoverSwoopXSpeed_A2C1C7:
     dw $0100                                                             ;A2C1C7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_Geruta_SetFinishedSwoopStartAnimationFlag:
     LDX.W $0E54                                                          ;A2C1C9;
@@ -8818,20 +8852,26 @@ InstList_Holtz_Flames:
     dw Instruction_Common_GotoY                                          ;A2C6BC;
     dw InstList_Holtz_Flames                                             ;A2C6BE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HoltzConstants_A2C6C0:
     dw $0000,$0009,$000A,$000B,$000A                                     ;A2C6C0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 HoltzConstants_initialYVelocity:
     dw $0700                                                             ;A2C6CA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HoltzConstants_A2C6CC:
     dw $0700                                                             ;A2C6CC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 HoltzConstants_XSpeed:
     dw $0100                                                             ;A2C6CE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HoltzConstants_A2C6D0:
     dw $0100                                                             ;A2C6D0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_Holtz_SetAnimationFinishedFlag:
     LDX.W $0E54                                                          ;A2C6D2;
@@ -10025,10 +10065,12 @@ Function_Oum_Rising:
     RTS                                                                  ;A2CFD6;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PlayKetchupBeamSFX_A2CFD7:
     LDA.W #$0063                                                         ;A2CFD7;
     JSL.L QueueSound_Lib2_Max6                                           ;A2CFDA;
     RTS                                                                  ;A2CFDE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 SetOumInstList:
@@ -11343,6 +11385,7 @@ InstList_GRipper_MovingRight:
     dw Instruction_Common_GotoY                                          ;A2E1BF;
     dw InstList_GRipper_MovingRight                                      ;A2E1C1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_GRipper_FacingLeft_A2E1C3:
     dw $0010                                                             ;A2E1C3;
     dw Spritemap_GRipper_Ripper2_6                                       ;A2E1C5;
@@ -11354,6 +11397,7 @@ UNUSED_InstList_GRipper_FacingRight_A2E1CB:
     dw Spritemap_GRipper_Ripper2_7                                       ;A2E1CD;
     dw Instruction_CommonA2_GotoY                                        ;A2E1CF;
     dw UNUSED_InstList_GRipper_FacingRight_A2E1CB                        ;A2E1D1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_GRipper:
     LDX.W $0E54                                                          ;A2E1D3;
@@ -11470,16 +11514,19 @@ CheckIfGRipperMovedRightTooFar:
     RTS                                                                  ;A2E29A;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FrozenAI_GRipper_A2E29B:
     LDX.W $0E54                                                          ;A2E29B;
     JSL.L CommonA2_NormalEnemyFrozenAI                                   ;A2E29E;
     RTL                                                                  ;A2E2A2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTL_A2E2A3:
     RTL                                                                  ;A2E2A3;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyShot_A2E2A4:
     JSL.L NormalEnemyShotAI                                              ;A2E2A4;
     LDX.W $0E54                                                          ;A2E2A8;
@@ -11495,6 +11542,7 @@ UNUSED_EnemyShot_A2E2A4:
 
 .return:
     RTL                                                                  ;A2E2BF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Palette_Ripper2:
@@ -11525,6 +11573,7 @@ InstList_Ripper2_MovingLeft:
     dw Instruction_CommonA2_GotoY                                        ;A2E304;
     dw InstList_Ripper2_MovingLeft                                       ;A2E306;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Ripper2_FacingLeft_A2E308:
     dw $0010                                                             ;A2E308;
     dw Spritemap_GRipper_Ripper2_6                                       ;A2E30A;
@@ -11536,6 +11585,7 @@ UNUSED_InstList_Ripper2_FacingRight_A2E310:
     dw Spritemap_GRipper_Ripper2_7                                       ;A2E312;
     dw Instruction_Common_GotoY                                          ;A2E314;
     dw UNUSED_InstList_Ripper2_FacingRight_A2E310                        ;A2E316;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_Ripper2:
     LDX.W $0E54                                                          ;A2E318;
@@ -11607,10 +11657,12 @@ MainAI_Ripper2:
     RTL                                                                  ;A2E39F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FrozenAI_Ripper2_A2E3A0:
     LDX.W $0E54                                                          ;A2E3A0;
     JSL.L CommonA2_NormalEnemyFrozenAI                                   ;A2E3A3;
     RTL                                                                  ;A2E3A7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTL_A2E3A8:
@@ -12383,6 +12435,7 @@ InstList_Shutter_GrowthLevel3:
     dw Spritemap_Shutters_40px                                           ;A2E9AC;
     dw Instruction_CommonA2_Sleep                                        ;A2E9AE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Shutter_ShrinkingLoop_A2E9B0:
     dw $0004                                                             ;A2E9B0;
     dw Spritemap_Shutters_40px                                           ;A2E9B2;
@@ -12402,6 +12455,7 @@ UNUSED_InstList_Shutter_ShrinkingLoop_A2E9B0:
     dw UNUSED_Spritemap_Shutters_8px_A2ED38                              ;A2E9CE;
     dw Instruction_Common_GotoY                                          ;A2E9D0;
     dw UNUSED_InstList_Shutter_ShrinkingLoop_A2E9B0                      ;A2E9D2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_ShutterHorizontal:
     dw $0001                                                             ;A2E9D4;
@@ -12807,33 +12861,39 @@ Function_ShutterGrowing_Growing_Upwards_GrowthLevel3:
     RTS                                                                  ;A2ED32;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Load5_A2ED33:
     LDA.W #$0005                                                         ;A2ED33;
     RTL                                                                  ;A2ED36;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTL_A2ED37:
     RTL                                                                  ;A2ED37;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Shutters_8px_A2ED38:
     dw $0002,$0000                                                       ;A2ED38;
     db $FC                                                               ;A2ED3C;
     dw $2101,$01F8                                                       ;A2ED3D;
     db $FC                                                               ;A2ED41;
     dw $2100                                                             ;A2ED42;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Shutters_10px:
     dw $0001,$C3F8                                                       ;A2ED44;
     db $F8                                                               ;A2ED48;
     dw $2100                                                             ;A2ED49;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Shutters_18px_A2ED4B:
     dw $0002,$C3F8                                                       ;A2ED4B;
     db $FC                                                               ;A2ED4F;
     dw $2100,$C3F8                                                       ;A2ED50;
     db $F4                                                               ;A2ED54;
     dw $2100                                                             ;A2ED55;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Shutters_20px:
     dw $0002,$C3F8                                                       ;A2ED57;
@@ -12842,6 +12902,7 @@ Spritemap_Shutters_20px:
     db $F0                                                               ;A2ED60;
     dw $2100                                                             ;A2ED61;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Shutters_28px_A2ED63:
     dw $0003,$C3F8                                                       ;A2ED63;
     db $F8                                                               ;A2ED67;
@@ -12850,6 +12911,7 @@ UNUSED_Spritemap_Shutters_28px_A2ED63:
     dw $2100,$C3F8                                                       ;A2ED6D;
     db $EC                                                               ;A2ED71;
     dw $2100                                                             ;A2ED72;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Shutters_30px:
     dw $0003,$C3F8                                                       ;A2ED74;
@@ -12860,6 +12922,7 @@ Spritemap_Shutters_30px:
     db $E8                                                               ;A2ED82;
     dw $2100                                                             ;A2ED83;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Shutters_38px_A2ED85:
     dw $0004,$C3F8                                                       ;A2ED85;
     db $0C                                                               ;A2ED89;
@@ -12870,6 +12933,7 @@ UNUSED_Spritemap_Shutters_38px_A2ED85:
     dw $2100,$C3F8                                                       ;A2ED94;
     db $E4                                                               ;A2ED98;
     dw $2100                                                             ;A2ED99;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Shutters_40px:
     dw $0004,$C3F8                                                       ;A2ED9B;

--- a/src/bank_A3.asm
+++ b/src/bank_A3.asm
@@ -169,6 +169,7 @@ Instruction_CommonA3_CallFunctionInY_WithA:
     RTL                                                                  ;A380B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA3_CallExternalFunctionInY_A380B5:
     LDA.W $0000,Y                                                        ;A380B5;
     STA.B $12                                                            ;A380B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA3_CallExternalFunctionInY_WithA_A380CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A380EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA3_GotoY:
@@ -791,11 +793,13 @@ MainAI_Metaree:
     JMP.W ($0FAA,X)                                                      ;A3897C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FunctionPointers_Metaree_A3897F:
     dw Function_Metaree_Idling                                           ;A3897F;
     dw Function_Metaree_PrepareToLaunchAttack                            ;A38981;
     dw Function_Metaree_LaunchedAttack                                   ;A38983;
     dw Function_Metaree_Burrowing                                        ;A38985;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Function_Metaree_Idling:
     LDX.W $0E54                                                          ;A38987;
@@ -961,6 +965,7 @@ SetMetareeInstListPointer:
     RTS                                                                  ;A38AD1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Metaree_DataPointers_A38AD2:
     dw UNUSED_Metaree_Data_A38ADC                                        ;A38AD2;
     dw UNUSED_Metaree_Data_A38AE6                                        ;A38AD4;
@@ -982,6 +987,7 @@ UNUSED_Metaree_Data_A38AFA:
 
 UNUSED_Metaree_Data_A38B04:
     dw $0001,$FFFC,$0000,$0002,$000C                                     ;A38B04;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RTL_A38B0E:
     RTL                                                                  ;A38B0E;
@@ -1211,11 +1217,13 @@ InstList_Fireflea:
     dw Instruction_Common_GotoY                                          ;A38CFF;
     dw InstList_Fireflea                                                 ;A38D01;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Fireflea_Data_A38D03:
     dw $1000,$2000,$4000,$6000,$8000,$A000,$C000,$E000                   ;A38D03;
 
 UNUSED_Fireflea_Data_A38D13:
     dw $0001,$2001,$4001,$6001,$8001                                     ;A38D13;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 FirefleaMovementRadii:
     dw $0008,$0010,$0018,$0020,$0028,$0030,$0038,$0040                   ;A38D1D;
@@ -2479,9 +2487,11 @@ InitAI_Sciser:
     JMP.W InitAI_Crawlers_Common                                         ;A396FA;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GetEnemyIndex_A396FD:
     LDX.W $0E54                                                          ;A396FD;
     RTL                                                                  ;A39700;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTL_A39701:
@@ -2811,9 +2821,11 @@ InitAI_Zero:
     JMP.W InitAI_Crawlers_Common                                         ;A39952;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GetEnemyIndex_A39955:
     LDX.W $0E54                                                          ;A39955;
     RTL                                                                  ;A39958;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RTL_A39959:
@@ -3937,6 +3949,7 @@ CalculateMovingForwardSpeeds:
     RTS                                                                  ;A3A1AF;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CalculateMovingForwardVelocities_A3A1B0:
     LDA.W $0FB4,X                                                        ;A3A1B0;
     AND.W #$00FF                                                         ;A3A1B3;
@@ -3959,6 +3972,7 @@ UNUSED_CalculateMovingForwardVelocities_A3A1B0:
     LDA.W $0E38                                                          ;A3A1EB;
     STA.L $7E7804,X                                                      ;A3A1EE;
     RTS                                                                  ;A3A1F2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CalculateMovingLeftVelocities:
@@ -6487,14 +6501,18 @@ SetZoaInstList:
     RTS                                                                  ;A3B556;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GetEnemyIndex_A3B557:
     LDX.W $0E54                                                          ;A3B557;
     RTL                                                                  ;A3B55A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GetEnemyIndex_A3B55B:
     LDX.W $0E54                                                          ;A3B55B;
     RTL                                                                  ;A3B55E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Spritemap_Zoa_0:
@@ -6615,6 +6633,7 @@ InstList_Viola_Normal:
     dw Instruction_Common_GotoY                                          ;A3B627;
     dw InstList_Viola_Normal                                             ;A3B629;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Viola_XFlipped_A3B62B:
     dw $0006                                                             ;A3B62B;
     dw UNUSED_Spritemap_Viola_XFlipped_A3B6C1                            ;A3B62D;
@@ -6646,6 +6665,7 @@ UNUSED_InstList_Viola_XFlipped_A3B62B:
     dw UNUSED_Spritemap_Viola_XFlipped_A3B6C8                            ;A3B661;
     dw Instruction_Common_GotoY                                          ;A3B663;
     dw UNUSED_InstList_Viola_XFlipped_A3B62B                             ;A3B665;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitialInstListPointers_Viola:
     dw InstList_Viola_UpsideRight                                        ;A3B667;
@@ -6706,6 +6726,7 @@ Spritemap_Viola_Normal_7:
     db $F8                                                               ;A3B6BE;
     dw $210E                                                             ;A3B6BF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Viola_XFlipped_A3B6C1:
     dw $0001,$81F8                                                       ;A3B6C1;
     db $F8                                                               ;A3B6C5;
@@ -6753,6 +6774,7 @@ UNUSED_CrashIfEnemyInitParamIsNonZero_A3B6F9:
 .crash:
     BNE .crash                                                           ;A3B6FF;
     RTL                                                                  ;A3B701;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Palette_Bang:
@@ -7202,6 +7224,7 @@ InstList_Bang_Electricity_Growth3_4_Growing:
     dw Instruction_Common_GotoY                                          ;A3BA38;
     dw InstList_Bang_Electricity_Growth3_4_Growing                       ;A3BA3A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNSUED_InstList_Bang_Electricity_Growing_A3BA3C:
     dw $0002                                                             ;A3BA3C;
     dw UNUSED_Spritemap_Bang_Electricity_A3C5AE                          ;A3BA3E;
@@ -7233,6 +7256,7 @@ UNSUED_InstList_Bang_Electricity_Growing_A3BA3C:
     dw UNUSED_Spritemap_Bang_Electricity_A3C632                          ;A3BA72;
     dw Instruction_Common_GotoY                                          ;A3BA74;
     dw UNSUED_InstList_Bang_Electricity_Growing_A3BA3C                   ;A3BA76;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_Bang_PlayAcquiredSuitSFX:
     PHY                                                                  ;A3BA78;
@@ -8537,6 +8561,7 @@ Spritemap_Bang_Growth4_Idling_7:
     db $F1                                                               ;A3C482;
     dw $3140                                                             ;A3C483;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Bang_Growth4_Idling_A3C485:
     dw $0001,$C3F8                                                       ;A3C485;
     db $F8                                                               ;A3C489;
@@ -8568,6 +8593,7 @@ UNUSED_Spritemap_Bang_Growth4_Idling_A3C4A9:
     dw $314A,$C3F0                                                       ;A3C4B8;
     db $F1                                                               ;A3C4BC;
     dw $3148                                                             ;A3C4BD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Bang_Growth4_Idling_8:
     dw $0001,$C3F8                                                       ;A3C4BF;
@@ -8702,6 +8728,7 @@ Spritemap_Bang_Growth4_Growing_A:
     db $F8                                                               ;A3C5AB;
     dw $316C                                                             ;A3C5AC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Bang_Electricity_A3C5AE:
     dw $0002,$0006                                                       ;A3C5AE;
     db $FC                                                               ;A3C5B2;
@@ -8785,6 +8812,7 @@ UNUSED_Spritemap_Bang_Electricity_A3C632:
     dw $3161,$01F5                                                       ;A3C637;
     db $03                                                               ;A3C63B;
     dw $7163                                                             ;A3C63C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Skree:
     dw $3800,$3F57,$2E4D,$00E2,$0060,$3AB0,$220B,$1166                   ;A3C63E;
@@ -8861,11 +8889,13 @@ MainAI_Skree:
     JMP.W ($0FAA,X)                                                      ;A3C6CA;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_FunctionPointers_Skree_A3C6CD:
     dw Function_Skree_Idling                                             ;A3C6CD;
     dw Function_Skree_PrepareToLaunchAttack                              ;A3C6CF;
     dw Function_Skree_LaunchedAttack                                     ;A3C6D1;
     dw Function_Skree_Burrowing                                          ;A3C6D3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Function_Skree_Idling:
     LDX.W $0E54                                                          ;A3C6D5;
@@ -9661,6 +9691,7 @@ Instruction_Yard_GoBack4BytesIfHidingOr50PercentChance:
     RTL                                                                  ;A3CC91;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_Yard_A3CC92:
     NOP                                                                  ;A3CC92;
     PHY                                                                  ;A3CC93;
@@ -9675,6 +9706,7 @@ UNUSED_Instruction_Yard_A3CC92:
 .notTurningAround:
     PLY                                                                  ;A3CCA0;
     RTL                                                                  ;A3CCA1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 YardCrawlingSpeeds:
@@ -10526,6 +10558,7 @@ SetYardAirborneInstList:
     dw InstList_Yard_Airborne_FacingRight_0                              ;A3D311;
     dw InstList_Yard_Hidden_UpsideUp_MovingRight                         ;A3D313;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MakeYardFaceSamus_A3D315:
     LDA.L $7E780A,X                                                      ;A3D315;
     BEQ .turningEnabled                                                  ;A3D319;
@@ -10551,6 +10584,7 @@ UNUSED_MakeYardFaceSamus_A3D315:
     CMP.W $0AFA                                                          ;A3D338;
     BCS TurnYardAround                                                   ;A3D33B;
     RTL                                                                  ;A3D33D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MakeYardFaceSamusHorizontally:
@@ -10700,6 +10734,7 @@ CheckIfSamusIsDirectingTowardsYard:
     RTS                                                                  ;A3D445;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CheckIfYardIsMovingTheDirectionSamusIsFacing_A3D446:
     LDA.W $0FA8,X                                                        ;A3D446;
     BPL .positiveXVelocity                                               ;A3D449;
@@ -10726,6 +10761,7 @@ UNUSED_CheckIfYardIsMovingTheDirectionSamusIsFacing_A3D446:
 .movingOppositeDirection:
     SEC                                                                  ;A3D467;
     RTS                                                                  ;A3D468;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EnemyShot_Yard:
@@ -11300,12 +11336,14 @@ Spritemap_Yard_3F:
     db $F8                                                               ;A3D881;
     dw $A126                                                             ;A3D882;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D884:
     dw $0002,$C3FB                                                       ;A3D884;
     db $F6                                                               ;A3D888;
     dw $2120,$C3F5                                                       ;A3D889;
     db $F8                                                               ;A3D88D;
     dw $2100                                                             ;A3D88E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_40:
     dw $0002,$C3F5                                                       ;A3D890;
@@ -11328,12 +11366,14 @@ Spritemap_Yard_42:
     db $F6                                                               ;A3D8B1;
     dw $E108                                                             ;A3D8B2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D8B4:
     dw $0002,$C3FA                                                       ;A3D8B4;
     db $FB                                                               ;A3D8B8;
     dw $E124,$C3F8                                                       ;A3D8B9;
     db $F5                                                               ;A3D8BD;
     dw $E108                                                             ;A3D8BE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_43:
     dw $0002,$C3F8                                                       ;A3D8C0;
@@ -11356,12 +11396,14 @@ Spritemap_Yard_45:
     db $F8                                                               ;A3D8E1;
     dw $E100                                                             ;A3D8E2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D8E4:
     dw $0002,$C3F5                                                       ;A3D8E4;
     db $FA                                                               ;A3D8E8;
     dw $E120,$C3FB                                                       ;A3D8E9;
     db $F8                                                               ;A3D8ED;
     dw $E100                                                             ;A3D8EE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_46:
     dw $0002,$C3FB                                                       ;A3D8F0;
@@ -11384,12 +11426,14 @@ Spritemap_Yard_48:
     db $FA                                                               ;A3D911;
     dw $2108                                                             ;A3D912;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D914:
     dw $0002,$C3F6                                                       ;A3D914;
     db $F5                                                               ;A3D918;
     dw $2124,$C3F8                                                       ;A3D919;
     db $FB                                                               ;A3D91D;
     dw $2108                                                             ;A3D91E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_49:
     dw $0002,$C3F8                                                       ;A3D920;
@@ -11460,12 +11504,14 @@ Spritemap_Yard_53:
     db $FA                                                               ;A3D98D;
     dw $2108                                                             ;A3D98E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D990:
     dw $0002,$C3F5                                                       ;A3D990;
     db $F6                                                               ;A3D994;
     dw $6120,$C3FB                                                       ;A3D995;
     db $F8                                                               ;A3D999;
     dw $6100                                                             ;A3D99A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_54:
     dw $0002,$C3FB                                                       ;A3D99C;
@@ -11488,12 +11534,14 @@ Spritemap_Yard_56:
     db $F6                                                               ;A3D9BD;
     dw $A108                                                             ;A3D9BE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D9C0:
     dw $0002,$C3F6                                                       ;A3D9C0;
     db $FB                                                               ;A3D9C4;
     dw $A124,$C3F8                                                       ;A3D9C5;
     db $F5                                                               ;A3D9C9;
     dw $A108                                                             ;A3D9CA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_57:
     dw $0002,$C3F8                                                       ;A3D9CC;
@@ -11516,12 +11564,14 @@ Spritemap_Yard_59:
     db $F8                                                               ;A3D9ED;
     dw $A100                                                             ;A3D9EE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3D9F0:
     dw $0002,$C3FB                                                       ;A3D9F0;
     db $FA                                                               ;A3D9F4;
     dw $A120,$C3F5                                                       ;A3D9F5;
     db $F8                                                               ;A3D9F9;
     dw $A100                                                             ;A3D9FA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_5A:
     dw $0002,$C3F5                                                       ;A3D9FC;
@@ -11544,12 +11594,14 @@ Spritemap_Yard_5C:
     db $FA                                                               ;A3DA1D;
     dw $6108                                                             ;A3DA1E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Yard_A3DA20:
     dw $0002,$C3FA                                                       ;A3DA20;
     db $F5                                                               ;A3DA24;
     dw $6124,$C3F8                                                       ;A3DA25;
     db $FB                                                               ;A3DA29;
     dw $6108                                                             ;A3DA2A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Yard_5D:
     dw $0002,$C3F8                                                       ;A3DA2C;
@@ -12701,6 +12753,7 @@ Spritemap_Crawlers_UpsideUp_FacingRight_4:
     db $F8                                                               ;A3E353;
     dw $2100                                                             ;A3E354;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Crawlers_UpsideUp_FacingLeft_A3E356:
     dw $0004,$01F5                                                       ;A3E356;
     db $00                                                               ;A3E35A;
@@ -12755,6 +12808,7 @@ UNUSED_Spritemap_Crawlers_UpsideUp_FacingLeft_A3E3AE:
     dw $6102,$81FF                                                       ;A3E3BD;
     db $F8                                                               ;A3E3C1;
     dw $6100                                                             ;A3E3C2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Crawlers_UpsideLeft_0:
     dw $0004,$0000                                                       ;A3E3C4;
@@ -13565,8 +13619,10 @@ Instruction_Metroid_PlayRandomMetroidSFX:
     RTL                                                                  ;A3EAC5;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 .unused:
     dw $00B4,$00BE,$00C8,$00D2,$00DC,$00E6,$00F0,$00FA                   ;A3EAC6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 .SFX:
     dw $0050,$0058,$005A,$0050,$0058,$005A,$0058,$005A                   ;A3EAD6;
@@ -14263,6 +14319,7 @@ PowerBombReaction_Metroid:
     RTL                                                                  ;A3F070;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Metroid_Shell_A3F071:
     dw $000A,$0010                                                       ;A3F071;
     db $04                                                               ;A3F075;
@@ -14331,6 +14388,7 @@ UNUSED_Spritemap_Metroid_Shell_A3F0D9:
     dw $2126,$81F0                                                       ;A3F106;
     db $EC                                                               ;A3F10A;
     dw $2106                                                             ;A3F10B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Metroid_Insides_0:
     dw $0008,$0010                                                       ;A3F10D;
@@ -14404,6 +14462,7 @@ Spritemap_Metroid_Insides_3:
     db $F0                                                               ;A3F1A8;
     dw $214A                                                             ;A3F1A9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Metroid_Electricity_A3F1AB:
     dw $0003,$0000                                                       ;A3F1AB;
     db $EC                                                               ;A3F1AF;
@@ -14599,6 +14658,7 @@ UNUSED_Spritemap_Metroid_Electricity_A3F30A:
     dw $0001,$0000                                                       ;A3F30A;
     db $EC                                                               ;A3F30E;
     dw $217E                                                             ;A3F30F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Freespace_BankA3_F311:                                                   ;A3F311;
 ; $CEF bytes

--- a/src/bank_A4.asm
+++ b/src/bank_A4.asm
@@ -169,6 +169,7 @@ Instruction_CommonA4_CallFunctionInY_WithA:
     RTL                                                                  ;A480B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA4_CallExternalFunctionInY_A480B5:
     LDA.W $0000,Y                                                        ;A480B5;
     STA.B $12                                                            ;A480B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA4_CallExternalFunctionInY_WithA_A480CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A480EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA4_GotoY:
@@ -796,6 +798,7 @@ FightAI_Crocomire_1C_UnusedSequence_SetInitialInstList:
     RTS                                                                  ;A488ED;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ChargeCrocomireForwardOneStepAfterDelay_A488EE:
     LDX.W $0E54                                                          ;A488EE;
     JSR.W FightAI_Crocomire_0_LockUp_SetInitialInstList                  ;A488F1;
@@ -812,6 +815,7 @@ UNUSED_ChargeCrocomireForwardOneStepAfterDelay_A488EE:
 
 .return:
     RTS                                                                  ;A4890A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 ChargeCrocomireForwardOneStep:
@@ -970,9 +974,11 @@ UNUSED_FightAI_Crocomire_28_MovingClaws_A489F9:
     RTS                                                                  ;A48A39;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palette_Crocomire_A48A3A:
     dw $3800,$7FFF,$6B40,$6A80,$6980,$68E0,$6800,$5294                   ;A48A3A;
     dw $39CE,$2108,$08BF,$0895,$039F,$023A,$0176,$0000                   ;A48A4A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_Crocomire:
     REP #$30                                                             ;A48A5A;
@@ -1639,9 +1645,11 @@ CollapseCrocomiresBridge:
     RTS                                                                  ;A48FC1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveEnemyDownBy14_12_A48FC2:
     JSL.L MoveEnemyDownBy_14_12                                          ;A48FC2;
     RTL                                                                  ;A48FC6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_Crocomire_ShakeScreen:
@@ -2304,9 +2312,11 @@ MainAI_Crocomire_DeathSequence_12_2E_Hop_3_4_LoadMeltTiles:
     RTS                                                                  ;A494B1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_UploadCrocomireMeltingTilesToVRAM_A494B2:
     JSR.W MainAI_Crocomire_DeathSequence_14_30_Hop_3_6_UploadingToVRAM   ;A494B2;
     RTS                                                                  ;A494B5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MainAI_Crocomire_DeathSequence_14_30_Hop_3_6_UploadingToVRAM:
@@ -4076,6 +4086,7 @@ InstList_Crocomire_ProjectileAttack_1:
     dw Instruction_Common_GotoY                                          ;A4BBAA;
     dw InstList_Crocomire_ProjectileAttack_1                             ;A4BBAC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Crocomire_A4BBAE:
     dw $0004                                                             ;A4BBAE;
     dw ExtendedSpritemap_Crocomire_14                                    ;A4BBB0;
@@ -4091,6 +4102,7 @@ UNUSED_InstList_Crocomire_A4BBAE:
     dw ExtendedSpritemap_Crocomire_16                                    ;A4BBC4;
     dw Instruction_Crocomire_MoveLeft4Pixels_SpawnBigDustCloud           ;A4BBC6;
     dw Instruction_Crocomire_FightAI                                     ;A4BBC8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Crocomire_StepForwardAfterDelay:
     dw $00B4                                                             ;A4BBCA;
@@ -4456,6 +4468,7 @@ InstList_CrocomireTongue_Fight:
     dw Instruction_Common_GotoY                                          ;A4BE66;
     dw InstList_CrocomireTongue_Fight                                    ;A4BE68;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_CrocomireTongue_ReverseVersionOfFight_A4BE6A:
     dw $0005                                                             ;A4BE6A;
     dw ExtendedSpritemap_Crocomire_13                                    ;A4BE6C;
@@ -4467,6 +4480,7 @@ UNUSED_InstList_CrocomireTongue_ReverseVersionOfFight_A4BE6A:
     dw ExtendedSpritemap_Crocomire_10                                    ;A4BE78;
     dw Instruction_Common_GotoY                                          ;A4BE7A;
     dw InstList_CrocomireTongue_Fight                                    ;A4BE7C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_CrocomireTongue_NearSpikeWallCharge_0:
     dw $0005                                                             ;A4BE7E;
@@ -4899,6 +4913,7 @@ ExtendedSpritemap_Crocomire_ChargeForward_StepBack_B:
     dw ExtendedTilemap_Crocomire_7                                       ;A4C218;
     dw Hitbox_Crocomire_F                                                ;A4C21A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_Crocomire_A4C21C:
     dw $0006,$0001,$000A                                                 ;A4C21C;
     dw Spritemap_Crocomire_0                                             ;A4C222;
@@ -4981,6 +4996,7 @@ UNUSED_ExtendedSpritemap_Crocomire_A4C2B2:
     dw $0000,$0000                                                       ;A4C2E4;
     dw ExtendedTilemap_Crocomire_6                                       ;A4C2E8;
     dw Hitbox_Crocomire_F                                                ;A4C2EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_Crocomire_0:
     dw $0007,$0000,$000B                                                 ;A4C2EC;
@@ -5309,6 +5325,7 @@ ExtendedSpritemap_Crocomire_9:
     dw ExtendedTilemap_Crocomire_7                                       ;A4C61E;
     dw Hitbox_Crocomire_F                                                ;A4C620;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_Crocomire_A4C622:
     dw $0001,$0000,$0000                                                 ;A4C622;
     dw ExtendedTilemap_Crocomire_3                                       ;A4C628;
@@ -5338,6 +5355,7 @@ UNUSED_ExtendedSpritemap_Crocomire_A4C654:
     dw $0001,$0000,$0000                                                 ;A4C654;
     dw ExtendedTilemap_Crocomire_8                                       ;A4C65A;
     dw Hitbox_Crocomire_F                                                ;A4C65C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_Crocomire_10:
     dw $0001,$FFE0,$FFE8                                                 ;A4C65E;
@@ -5359,6 +5377,7 @@ ExtendedSpritemap_Crocomire_13:
     dw Spritemap_Crocomire_1A                                            ;A4C682;
     dw Hitbox_Crocomire_9                                                ;A4C684;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_Crocomire_A4C686:
     dw $0001,$0000,$0000                                                 ;A4C686;
     dw Spritemap_Crocomire_1B                                            ;A4C68C;
@@ -5373,6 +5392,7 @@ UNUSED_ExtendedSpritemap_Crocomire_A4C69A:
     dw $0001,$0000,$0000                                                 ;A4C69A;
     dw ExtendedTilemap_Crocomire_A                                       ;A4C6A0;
     dw Hitbox_Crocomire_10                                               ;A4C6A2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_Crocomire_14:
     dw $0007,$0003,$000B                                                 ;A4C6A4;
@@ -5839,8 +5859,10 @@ LoadEnemyIndexAndRTL:
     RTL                                                                  ;A4CB04;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_Crocomire_A4CB05:
     dw $0000                                                             ;A4CB05;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_Crocomire_0:
     dw $0001,$FFB2,$0020,$FFF0,$002B                                     ;A4CB07;
@@ -5875,8 +5897,10 @@ Hitbox_Crocomire_6:
     dw EnemyTouch_Crocomire_Claws                                        ;A4CB59;
     dw EnemyShot_Crocomire_Nothing                                       ;A4CB5B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_Crocomire_A4CB5D:
     dw $0000                                                             ;A4CB5D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_Crocomire_7:
     dw $0001,$FFC5,$FFF7,$FFF0,$0005                                     ;A4CB5F;
@@ -5888,6 +5912,7 @@ Hitbox_Crocomire_8:
     dw EnemyTouch_Crocomire_Claws                                        ;A4CB77;
     dw EnemyShot_Crocomire_Nothing                                       ;A4CB79;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_Crocomire_A4CB7B:
     dw $0001,$FFFB,$FFFB,$0004,$0004                                     ;A4CB7B;
     dw EnemyTouch_Crocomire_Claws                                        ;A4CB85;
@@ -5907,6 +5932,7 @@ UNUSED_Hitbox_Crocomire_A4CBA5:
     dw $0001,$FFF7,$FFF8,$0008,$0007                                     ;A4CBA5;
     dw EnemyTouch_Crocomire_Claws                                        ;A4CBAF;
     dw EnemyShot_Crocomire_Nothing                                       ;A4CBB1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_Crocomire_9:
     dw $0000                                                             ;A4CBB3;
@@ -5959,6 +5985,7 @@ Hitbox_Crocomire_10:
 Hitbox_Crocomire_11:
     dw $0000                                                             ;A4CC3B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Crocomire_A4CC3D:
     dw $0011,$01E4                                                       ;A4CC3D;
     db $18                                                               ;A4CC41;
@@ -6243,6 +6270,7 @@ UNUSED_Spritemap_Crocomire_A4CE8B:
     dw $0001,$81F8                                                       ;A4CE8B;
     db $F8                                                               ;A4CE8F;
     dw $718E                                                             ;A4CE90;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Crocomire_0:
     dw $0009,$81C3                                                       ;A4CE92;
@@ -6569,6 +6597,7 @@ Spritemap_Crocomire_10:
     db $F9                                                               ;A4D15E;
     dw $312B                                                             ;A4D15F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Crocomire_A4D161:
     dw $0008,$0002                                                       ;A4D161;
     db $08                                                               ;A4D165;
@@ -6587,6 +6616,7 @@ UNUSED_Spritemap_Crocomire_A4D161:
     dw $314B,$8001                                                       ;A4D184;
     db $F9                                                               ;A4D188;
     dw $312B                                                             ;A4D189;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Crocomire_11:
     dw $0008,$000C                                                       ;A4D18B;
@@ -6645,6 +6675,7 @@ Spritemap_Crocomire_13:
     db $F1                                                               ;A4D206;
     dw $312B                                                             ;A4D207;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Crocomire_A4D209:
     dw $0009,$802D                                                       ;A4D209;
     db $1A                                                               ;A4D20D;
@@ -6724,6 +6755,7 @@ UNUSED_Spritemap_Crocomire_A4D28C:
     dw $7104,$800C                                                       ;A4D2B4;
     db $0D                                                               ;A4D2B8;
     dw $7102                                                             ;A4D2B9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Crocomire_14:
     dw $0007,$81E6                                                       ;A4D2BB;
@@ -6742,6 +6774,7 @@ Spritemap_Crocomire_14:
     db $FA                                                               ;A4D2DD;
     dw $30E2                                                             ;A4D2DE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Crocomire_A4D2E0:
     dw $0009,$0000                                                       ;A4D2E0;
     db $F0                                                               ;A4D2E4;
@@ -6817,6 +6850,7 @@ UNUSED_Spritemap_Crocomire_A4D363:
     dw $F104,$801B                                                       ;A4D381;
     db $01                                                               ;A4D385;
     dw $F102                                                             ;A4D386;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Crocomire_15:
     dw $0009,$0000                                                       ;A4D388;
@@ -6860,6 +6894,7 @@ Spritemap_Crocomire_16:
     db $E2                                                               ;A4D3E3;
     dw $B102                                                             ;A4D3E4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Crocomire_A4D3E6:
     dw $0004,$0000                                                       ;A4D3E6;
     db $F8                                                               ;A4D3EA;
@@ -6903,6 +6938,7 @@ UNUSED_Spritemap_Crocomire_A4D428:
     dw $B0D3,$01F8                                                       ;A4D437;
     db $F8                                                               ;A4D43B;
     dw $30D3                                                             ;A4D43C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Crocomire_17:
     dw $0004,$0008                                                       ;A4D43E;
@@ -8434,10 +8470,12 @@ ExtendedSpritemap_CrocomireCorpse_20:
     dw Spritemap_CrocomireCorpse_1F                                      ;A4E71C;
     dw Hitbox_CrocomireCorspe_Empty                                      ;A4E71E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_CrocomireCorspe_A4E720:
     dw $0001,$FFE6,$FFE2,$0026,$001D                                     ;A4E720;
     dw RTL_A4B950                                                        ;A4E72A;
     dw EnemyShot_Crocomire_SpawnShotExplosion                            ;A4E72C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_CrocomireCorspe:
     dw $0002,$FFDA,$FFF0,$0000,$001F                                     ;A4E72E;
@@ -8450,6 +8488,7 @@ Hitbox_CrocomireCorspe:
 Hitbox_CrocomireCorspe_Empty:
     dw $0000                                                             ;A4E748;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4E74A:
     dw $0011,$01E4                                                       ;A4E74A;
     db $18                                                               ;A4E74E;
@@ -8486,6 +8525,7 @@ UNUSED_Spritemap_CrocomireCorpse_A4E74A:
     dw $2FA2,$81DC                                                       ;A4E79A;
     db $E0                                                               ;A4E79E;
     dw $2FA0                                                             ;A4E79F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_0:
     dw $0011,$0014                                                       ;A4E7A1;
@@ -8524,6 +8564,7 @@ Spritemap_CrocomireCorpse_0:
     db $E0                                                               ;A4E7F5;
     dw $6FA0                                                             ;A4E7F6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4E7F8:
     dw $000A,$0018                                                       ;A4E7F8;
     db $0C                                                               ;A4E7FC;
@@ -8546,6 +8587,7 @@ UNUSED_Spritemap_CrocomireCorpse_A4E7F8:
     dw $2F80,$81E0                                                       ;A4E825;
     db $EC                                                               ;A4E829;
     dw $2F60                                                             ;A4E82A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_1:
     dw $000A,$01E0                                                       ;A4E82C;
@@ -8570,6 +8612,7 @@ Spritemap_CrocomireCorpse_1:
     db $EC                                                               ;A4E85D;
     dw $6F60                                                             ;A4E85E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4E860:
     dw $000F,$8020                                                       ;A4E860;
     db $10                                                               ;A4E864;
@@ -8602,6 +8645,7 @@ UNUSED_Spritemap_CrocomireCorpse_A4E860:
     dw $2F84,$81D0                                                       ;A4E8A6;
     db $00                                                               ;A4E8AA;
     dw $2F82                                                             ;A4E8AB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_2:
     dw $000F,$81D0                                                       ;A4E8AD;
@@ -8643,6 +8687,7 @@ Spritemap_CrocomireCorpse_3:
     db $F8                                                               ;A4E903;
     dw $2F6C                                                             ;A4E904;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4E906:
     dw $0002,$81F0                                                       ;A4E906;
     db $F8                                                               ;A4E90A;
@@ -8654,6 +8699,7 @@ UNUSED_Spritemap_CrocomireCorpse_A4E912:
     dw $0001,$81F8                                                       ;A4E912;
     db $F8                                                               ;A4E916;
     dw $6F60                                                             ;A4E917;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_4:
     dw $0001,$81F8                                                       ;A4E919;
@@ -8735,6 +8781,7 @@ Spritemap_CrocomireCorpse_F:
     db $F8                                                               ;A4E99C;
     dw $6F8E                                                             ;A4E99D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4E99F:
     dw $0009,$81C3                                                       ;A4E99F;
     db $1A                                                               ;A4E9A3;
@@ -9135,6 +9182,7 @@ UNUSED_Spritemap_CrocomireCorpse_A4ECEC:
     dw $214B,$8000                                                       ;A4ED0F;
     db $F1                                                               ;A4ED13;
     dw $212B                                                             ;A4ED14;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_10:
     dw $0009,$802D                                                       ;A4ED16;
@@ -9178,6 +9226,7 @@ Spritemap_CrocomireCorpse_11:
     db $0F                                                               ;A4ED71;
     dw $6302                                                             ;A4ED72;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4ED74:
     dw $0007,$8024                                                       ;A4ED74;
     db $1C                                                               ;A4ED78;
@@ -9232,6 +9281,7 @@ UNUSED_Spritemap_CrocomireCorpse_A4EDC8:
     dw $20E2,$81BD                                                       ;A4EDE6;
     db $FA                                                               ;A4EDEA;
     dw $20E2                                                             ;A4EDEB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_12:
     dw $0009,$0000                                                       ;A4EDED;
@@ -9309,6 +9359,7 @@ Spritemap_CrocomireCorpse_15:
     db $01                                                               ;A4EE92;
     dw $E302                                                             ;A4EE93;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_CrocomireCorpse_A4EE95:
     dw $0009,$0000                                                       ;A4EE95;
     db $08                                                               ;A4EE99;
@@ -9629,6 +9680,7 @@ UNUSED_ExtendedTilemap_CrocomireCorpse_A4F539:
     dw $1C86,$1C87,$1C88,$1C89,$1C8A,$0140,$0141,$2382                   ;A4F5C9;
     dw $000B,$01FF,$1C93,$1C94,$1C95,$1C96,$1C97,$1C98                   ;A4F5D9;
     dw $1C99,$1C9A,$0150,$0151,$FFFF                                     ;A4F5E9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CrocomireCorpse_16:
     dw $0001,$01FC                                                       ;A4F5F3;

--- a/src/bank_A5.asm
+++ b/src/bank_A5.asm
@@ -169,6 +169,7 @@ Instruction_CommonA5_CallFunctionInY_WithA:
     RTL                                                                  ;A580B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA5_CallExternalFunctionInY_A580B5:
     LDA.W $0000,Y                                                        ;A580B5;
     STA.B $12                                                            ;A580B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA5_CallExternalFunctionInY_WithA_A580CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A580EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA5_GotoY:
@@ -704,6 +706,7 @@ Function_DraygonBody_SwoopRight_Descending:
     RTS                                                                  ;A58900;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Draygon_FireGoop_A58901:
     LDA.W $05B6                                                          ;A58901;
     AND.W #$000F                                                         ;A58904;
@@ -721,6 +724,7 @@ UNUSED_Draygon_FireGoop_A58901:
 
 .return:
     RTS                                                                  ;A58921;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_DraygonBody_SwoopRight_Apex:
@@ -2165,6 +2169,7 @@ Instruction_Draygon_SetInstList_Body_Eye_Tail_Arms:
     RTL                                                                  ;A5950C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 Unused_DraygonInstListPointers_A5950D:
     dw InstList_DraygonArms_FacingLeft_Idle_0                            ;A5950D;
     dw InstList_DraygonArms_FacingLeft_NearSwoopApex                     ;A5950F;
@@ -2198,6 +2203,7 @@ Unused_DraygonInstListPointers_A5950D:
     dw InstList_DraygonTail_FacingRight_Idle_0                           ;A59547;
     dw Debug_InstList_DraygonTail_FacingRight_FakeTailWhip               ;A59549;
     dw $0000                                                             ;A5954B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 HurtAI_Draygon:
     LDY.W #Palette_Draygon_BG12_5                                        ;A5954D;
@@ -2554,6 +2560,7 @@ InstList_DraygonArms_FacingLeft_Idle_0:
 InstList_DraygonArms_FacingLeft_Idle_1:
     dw Instruction_Common_Sleep                                          ;A59803;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DraygonArms_A59805:
     dw $0001                                                             ;A59805;
     dw ExtendedSpritemap_Draygon_1D                                      ;A59807;
@@ -2562,6 +2569,7 @@ UNUSED_InstList_DraygonArms_A59805:
     dw $0040                                                             ;A5980D;
     dw ExtendedSpritemap_Draygon_1B                                      ;A5980F;
     dw Instruction_Common_Sleep                                          ;A59811;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DraygonArms_FacingLeft_NearSwoopApex:
     dw $0001                                                             ;A59813;
@@ -2623,6 +2631,7 @@ InstList_DraygonArms_FacingLeft_Dying:
     dw Instruction_Common_GotoY                                          ;A59877;
     dw InstList_DraygonBody_Dying_0                                      ;A59879;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DraygonBody_A5987B:
     dw $0005                                                             ;A5987B;
     dw ExtendedSpritemap_Draygon_C                                       ;A5987D;
@@ -2631,6 +2640,7 @@ UNUSED_InstList_DraygonBody_A5987B:
     dw $0005                                                             ;A59883;
     dw ExtendedSpritemap_Draygon_A                                       ;A59885;
     dw Instruction_Common_Sleep                                          ;A59887;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DraygonBody_FacingLeft_Idle:
     dw Instruction_Draygon_RoomLoadingInterruptCmd_BeginHUDDraw          ;A59889;
@@ -3074,6 +3084,7 @@ InstList_DraygonArms_FacingRight_Idle_0:
 InstList_DraygonArms_FacingRight_Idle_1:
     dw Instruction_Common_Sleep                                          ;A59BF6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DraygonArms_A59BF8:
     dw $0001                                                             ;A59BF8;
     dw ExtendedSpritemap_Draygon_4D                                      ;A59BFA;
@@ -3082,6 +3093,7 @@ UNUSED_InstList_DraygonArms_A59BF8:
     dw $0040                                                             ;A59C00;
     dw ExtendedSpritemap_Draygon_4B                                      ;A59C02;
     dw Instruction_Common_Sleep                                          ;A59C04;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DraygonArms_FacingRight_NearSwoopApex:
     dw $0001                                                             ;A59C06;
@@ -3146,6 +3158,7 @@ InstList_DraygonArms_FacingRight_Dying_0:
 InstList_DraygonBody_FacingRight_Dying_1:
     dw Instruction_Common_Sleep                                          ;A59C6E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DraygonBody_A59C70:
     dw $0005                                                             ;A59C70;
     dw ExtendedSpritemap_Draygon_3C                                      ;A59C72;
@@ -3154,6 +3167,7 @@ UNUSED_InstList_DraygonBody_A59C70:
     dw $0005                                                             ;A59C78;
     dw ExtendedSpritemap_Draygon_3A                                      ;A59C7A;
     dw Instruction_Common_Sleep                                          ;A59C7C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DraygonBody_FacingRight_Idle:
     dw Instruction_Draygon_RoomLoadingInterruptCmd_BeginHUDDraw_dup      ;A59C7E;
@@ -3235,6 +3249,7 @@ InstList_DraygonEye_FacingRight_Idle:
     dw Function_DraygonEye_FacingLeft                                    ;A59D08;
     dw Instruction_Common_Sleep                                          ;A59D0A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_DraygonEye_A59D0C:
     dw $0015                                                             ;A59D0C;
     dw ExtendedSpritemap_Draygon_42                                      ;A59D0E;
@@ -3244,6 +3259,7 @@ UNUSED_InstList_DraygonEye_A59D0C:
     dw ExtendedSpritemap_Draygon_44                                      ;A59D16;
     dw $000A                                                             ;A59D18;
     dw ExtendedSpritemap_Draygon_45                                      ;A59D1A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_DraygonEye_FacingRight_Dying_0:
     dw Instruction_Common_TimerInY                                       ;A59D1C;
@@ -3838,8 +3854,10 @@ HandleDraygonFightIntroDance:
 MovementLatencyForEachEvirSpriteObject:
     dw $FC80,$FD00,$FD80,$FE00                                           ;A5A19F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MovementLatencyForEachEvirSpriteObject_A5A1A7:
     dw $FE80,$FF00,$FF80,$0000                                           ;A5A1A7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DraygonDeathSequenceEvirSubSpeeds_X:
     dw $D4DA                                                             ;A5A1AF;
@@ -6936,6 +6954,7 @@ RTL_A5C5C6:
     RTL                                                                  ;A5C5C6;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DraygonFightIntroDanceData_KeikoLove_A5C5C7:
     db $01,$FF,$01,$00,$00,$FF,$01,$00,$01,$FF,$01,$00,$00,$FF,$01,$00   ;A5C5C7;
     db $01,$FF,$01,$00,$00,$FF,$01,$00,$01,$FF,$00,$FF,$01,$00,$01,$FF   ;A5C5D7;
@@ -7069,6 +7088,7 @@ UNUSED_DraygonFightIntroDanceData_KeikoLove_A5C5C7:
     db $01,$FF,$01,$FF,$01,$00,$01,$FF,$01,$00,$01,$FF,$01,$00,$01,$FF   ;A5CDD7;
     db $01,$00,$00,$FF,$01,$00,$01,$FF,$01,$00,$01,$FF,$01,$00,$01,$FF   ;A5CDE7;
     db $01,$00,$01,$FF,$01,$FF,$01,$00,$01,$FF,$01,$00,$01,$FF,$01,$00   ;A5CDF7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DraygonFightIntroDanceData_KeikoLove:
     db $03,$00,$03,$00,$03,$00,$02,$FF,$03,$00,$03,$FF,$03,$00,$02,$FF   ;A5CE07;
@@ -7350,6 +7370,7 @@ DraygonFightIntroDanceData_KeikoLove_EvirsAlreadyDeleted:
     db $FF,$02,$00,$03,$00,$02,$00,$02,$00,$03,$00,$02,$01,$02,$01,$02   ;A5DF27;
     db $01,$02,$00,$02,$02,$02,$01,$01,$01,$02,$01,$02,$02,$02,$02,$01   ;A5DF37;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DraygonFightIntroDanceData_KeikoLove_A5DF47:
     db $01,$02,$02,$02,$02,$01,$01,$02,$02,$02,$02,$01,$02,$02,$02,$01   ;A5DF47;
     db $02,$02,$02,$02,$02,$01,$02,$02,$01,$02,$02,$01,$02,$02,$02,$02   ;A5DF57;
@@ -7417,6 +7438,7 @@ UNUSED_DraygonFightIntroDanceData_KeikoLove_A5DF47:
     db $02,$00,$01,$00,$02,$00,$02,$00,$01,$00,$02,$00,$01,$00,$02,$00   ;A5E337;
     db $02,$00,$01,$00,$02,$00,$02,$00,$01,$00,$02,$00,$01,$00,$02,$00   ;A5E347;
     db $02,$00                                                           ;A5E357;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_SporeSpawn:
     dw $0000,$3F57,$2E4D,$00E2,$0060,$3AB0,$220B,$1166                   ;A5E359;
@@ -7720,6 +7742,7 @@ InstList_SporeSpawn_DeathSequence_2:
     dw Instruction_SporeSpawn_CallSporeSpawnDeathItemDropRoutine         ;A5E80D;
     dw Instruction_Common_Sleep                                          ;A5E80F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_SporeSpawn_SetMaxXRadiusAndAngles_A5E811:
     LDA.W $0000,Y                                                        ;A5E811;
     STA.L $7E7816                                                        ;A5E814;
@@ -7732,6 +7755,7 @@ UNUSED_Instruction_SporeSpawn_SetMaxXRadiusAndAngles_A5E811:
     ADC.W #$0006                                                         ;A5E828;
     TAY                                                                  ;A5E82B;
     RTL                                                                  ;A5E82C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_SporeSpawn_SetMaxXRadiusAndAngleDelta:
@@ -7746,6 +7770,7 @@ Instruction_SporeSpawn_SetMaxXRadiusAndAngleDelta:
     RTL                                                                  ;A5E83F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_SporeSpawn_MaxXRadiusInY_A5E840:
     LDA.W $0000,Y                                                        ;A5E840;
     STA.L $7E7816                                                        ;A5E843;
@@ -7780,6 +7805,7 @@ UNUSED_Instruction_SporeSpawn_AngleDeltaPlusY_A5E863:
     INY                                                                  ;A5E86F;
     INY                                                                  ;A5E870;
     RTL                                                                  ;A5E871;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_SporeSpawn_SporeGenerationFlagInY:
@@ -8598,6 +8624,7 @@ ExtendedSpritemap_SporeSpawn_Closed_Closing_Opening_7:
     dw Spritemap_SporeSpawn_D                                            ;A5EEF3;
     dw Hitbox_SporeSpawn_D                                               ;A5EEF5;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_SporeSpawn_A5EEF7:
     dw $0001,$0000,$0000                                                 ;A5EEF7;
     dw Spritemap_SporeSpawn_F                                            ;A5EEFD;
@@ -8632,6 +8659,7 @@ UNUSED_ExtendedSpritemap_SporeSpawn_A5EF33:
     dw $0001,$0000,$0000                                                 ;A5EF33;
     dw Spritemap_SporeSpawn_E                                            ;A5EF39;
     dw Hitbox_SporeSpawn_E                                               ;A5EF3B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_SporeSpawn_FullyOpen_0:
     dw $0002,$0000,$0000                                                 ;A5EF3D;

--- a/src/bank_A6.asm
+++ b/src/bank_A6.asm
@@ -169,6 +169,7 @@ Instruction_CommonA6_CallFunctionInY_WithA:
     RTL                                                                  ;A680B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA6_CallExternalFunctionInY_A680B5:
     LDA.W $0000,Y                                                        ;A680B5;
     STA.B $12                                                            ;A680B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA6_CallExternalFunctionInY_WithA_A680CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A680EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA6_GotoY:
@@ -855,6 +857,7 @@ MoveBoulderHorizontally:
     RTS                                                                  ;A68A1C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MoveBoulderHorizontallyWithLinearSpeedTable_A68A1D:
     LDX.W $0E54                                                          ;A68A1D;
     LDA.W $0F7C,X                                                        ;A68A20;
@@ -869,6 +872,7 @@ UNUSED_MoveBoulderHorizontallyWithLinearSpeedTable_A68A1D:
     ADC.W CommonEnemySpeeds_LinearlyIncreasing,Y                         ;A68A33;
     STA.W $0F7A,X                                                        ;A68A36;
     RTS                                                                  ;A68A39;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MoveBoulderVertically:
@@ -2928,10 +2932,12 @@ InstList_MiniKraid_FireSpit_FacingLeft:
     dw Instruction_Common_GotoY                                          ;A699F0;
     dw InstList_MiniKraid_ChooseAction                                   ;A699F2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_MiniKraid_Standing_FacingLeft_A699F4:
     dw $7FFF                                                             ;A699F4;
     dw Spritemap_MiniKraid_FiringSpit_FacingLeft_0                       ;A699F6;
     dw Instruction_Common_Sleep                                          ;A699F8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_MiniKraid_ChooseAction_duplicate_again2:
     dw Instruction_MiniKraid_ChooseAction                                ;A699FA;
@@ -2979,10 +2985,12 @@ InstList_MiniKraid_FireSpit_FacingRight:
     dw Instruction_Common_GotoY                                          ;A69A3E;
     dw InstList_MiniKraid_ChooseAction_duplicate_again2                  ;A69A40;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_MiniKraid_Standing_FacingRight_A69A42:
     dw $7FFF                                                             ;A69A42;
     dw Spritemap_MiniKraid_FiringSpit_FacingRight_0                      ;A69A44;
     dw Instruction_Common_Sleep                                          ;A69A46;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 MiniKraidSpitVelocityTable_leftward_X1:
     dw $FE00                                                             ;A69A48;
@@ -3235,6 +3243,7 @@ Instruction_MiniKraid_FireSpitRight:
     BRA FireMiniKraidSpit_Common                                         ;A69C09;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_PowerBombReaction_MiniKraid_A69C0B:
     LDX.W $0E54                                                          ;A69C0B;
     LDA.W $0F7A,X                                                        ;A69C0E;
@@ -3243,6 +3252,7 @@ UNUSED_PowerBombReaction_MiniKraid_A69C0B:
     STA.L $7EF436                                                        ;A69C18;
     JSL.L NormalEnemyPowerBombAI_NoDeathCheck_External                   ;A69C1C;
     BRA Reaction_MiniKraid_Common                                        ;A69C20;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EnemyTouch_MiniKraid:
@@ -3767,6 +3777,7 @@ Spritemap_MiniKraid_FiringSpit_FacingRight_2:
     db $FF                                                               ;A6A0DD;
     dw $6140                                                             ;A6A0DE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_MiniKraid_A6A0E0:
     dw $0001,$01FD                                                       ;A6A0E0;
     db $FD                                                               ;A6A0E4;
@@ -3781,6 +3792,7 @@ UNUSED_Spritemap_MiniKraid_A6A0EE:
     dw $0001,$01FC                                                       ;A6A0EE;
     db $FC                                                               ;A6A0F2;
     dw $610F                                                             ;A6A0F3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InitAI_Ridley:
     LDX.W $079F                                                          ;A6A0F5;
@@ -5398,6 +5410,7 @@ MainAI_Ridley:
     RTL                                                                  ;A6B26E;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Ridley_TrySamusGrab_A6B26F:
     LDA.L $7E783C                                                        ;A6B26F;
     ORA.L $7E7836                                                        ;A6B273;
@@ -5413,6 +5426,7 @@ UNUSED_Ridley_TrySamusGrab_A6B26F:
 
 .gotoGrabSamus:
     JMP.W GrabSamus                                                      ;A6B285;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 RidleyHurtAIMaxTimer:
@@ -5865,8 +5879,10 @@ Function_Ridley_USwoop_End:
     RTS                                                                  ;A6B5BD;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_A6B5BE:
     dw $FFE0,$0000,$0020                                                 ;A6B5BE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Function_Ridley_ConsiderTailbouncing:
     LDA.W #$000B                                                         ;A6B5C4;
@@ -6669,8 +6685,10 @@ Function_Ridley_DropSamus:
     RTS                                                                  ;A6BC27;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_A6BC28:
     dw $00B0,$0000,$0050                                                 ;A6BC28;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Function_Ridley_FallBackIntoPositionAfterDroppingSamus:
     DEC.W $0FB2                                                          ;A6BC2E;
@@ -7361,6 +7379,7 @@ DrawEmergencyText:
     dw $3986,$398E,$3986,$3993,$3988,$3986,$398F,$3984                   ;A6C164;
     dw $399A                                                             ;A6C174;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CycleColor_A6C176:
     LDX.W #$0016                                                         ;A6C176;
     LDA.L $7E8032                                                        ;A6C179;
@@ -7378,6 +7397,7 @@ UNUSED_CycleColor_A6C176:
   + AND.W #$001F                                                         ;A6C194;
     STA.L $7EC000,X                                                      ;A6C197;
     RTS                                                                  ;A6C19B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CycleEmergencyTextColors:
@@ -7643,6 +7663,7 @@ TypewriterCeresEscapeJapaneseTextTilemapTransfer_VRAM:
     dl TypewriterCeresEscapeJapanTextTilemap_Line1_Row1                  ;A6C3CF;
     dw $52EA,$0000                                                       ;A6C3D2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TypewriterCeresEscapeJapanTextTilemapTransfer_A6C3D6:
     dw $0018                                                             ;A6C3D6;
     dl TypewriterCeresEscapeJapanTextTilemap_Line0_Row0                  ;A6C3D8;
@@ -7653,6 +7674,7 @@ UNUSED_TypewriterCeresEscapeJapanTextTilemapTransfer_A6C3D6:
     dw $4ACA,$0016                                                       ;A6C3E9;
     dl TypewriterCeresEscapeJapanTextTilemap_Line1_Row1                  ;A6C3ED;
     dw $4AEA,$0000                                                       ;A6C3F0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 TypewriterCeresEscapeJapanTextTilemap_Line0_Row0:
     dw $3DA0,$3DA1,$3DA2,$3DA3,$3DA4,$3DA5,$3DA6,$3DA7                   ;A6C3F4;
@@ -9610,9 +9632,11 @@ UpdateTailPartRAMFromXToY:
     RTS                                                                  ;A6D3D3;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SetAllTailPartsToNotMoving_A6D3D4:
     LDA.W #$0000                                                         ;A6D3D4;
     BRA SetAllTailPartsToMovingOrNotMoving                               ;A6D3D7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 SetAllTailPartsToMoving:
@@ -9659,6 +9683,7 @@ Update_TailRotationDirection_Angle_DistanceFromRidley:
     RTS                                                                  ;A6D430;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CheckIfAllTailPartsAreMoving_A6D431:
     LDA.L $7E2020                                                        ;A6D431;
     AND.L $7E2034                                                        ;A6D435;
@@ -9675,6 +9700,7 @@ UNUSED_CheckIfAllTailPartsAreMoving_A6D431:
 .allPartsMoving:
     SEC                                                                  ;A6D451;
     RTS                                                                  ;A6D452;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 DealSuitAdjustedEnemyDamageToSamus:
@@ -10108,6 +10134,7 @@ CalculateRidleyXSpeed:
 CeresRidleyAccelerationDivisorIndex:
     db $10,$0F,$0E,$0D,$0C,$0B,$0A,$09,$08,$07,$06,$05,$04,$03,$02,$01   ;A6D712;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_A6D722:
     LDA.W #$0200                                                         ;A6D722;
     STA.B $16                                                            ;A6D725;
@@ -10239,6 +10266,7 @@ UNUSED_A6D798:
 
 .returnLower:
     RTS                                                                  ;A6D7FF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 UpdateRidleysUSwoopSpeedAndAngle:
@@ -10586,8 +10614,10 @@ RidleyRib_AnimationData:
     dw Tiles_RidleysRibsAndClaws_0                                       ;A6DA85;
     dw Tiles_RidleysRibsAndClaws_3                                       ;A6DA87;
 
+if !FEATURE_KEEP_UNREFERENCED
 RidleyRibAnimationDataPointer:
     dw RidleyRib_AnimationData                                           ;A6DA89; Unused?
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 TransferGraphicsForRidleysClawsHoldingSamusOrBabyMetroid:
     LDX.W #RidleyClawGraphicsPointers_released                           ;A6DA8B;
@@ -10881,6 +10911,7 @@ Spritemap_RidleyTail_Small:
     db $F8                                                               ;A6DCA2;
     dw $31E4                                                             ;A6DCA3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_RidleyTail_Large_A6DCA5:
     dw $0001,$C3F8                                                       ;A6DCA5;
     db $F8                                                               ;A6DCA9;
@@ -10895,6 +10926,7 @@ UNUSED_Spritemap_RidleyTail_Small_A6DCB3:
     dw $0001,$C3F8                                                       ;A6DCB3;
     db $F8                                                               ;A6DCB7;
     dw $71E4                                                             ;A6DCB8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RidleyTailTipSpritemapPointers:
     dw Spritemap_RidleyTailTip_PointingDown                              ;A6DCBA;
@@ -11235,6 +11267,7 @@ RidleyTail_vs_SamusProjectile_CollisionDetection:
     RTS                                                                  ;A6DF07;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ChangeRidleyProjectileDirection_A6DF08:
     LDA.W $0C04,Y                                                        ;A6DF08;
     AND.W #$000F                                                         ;A6DF0B;
@@ -11257,6 +11290,7 @@ UNUSED_ChangeRidleyProjectileDirection_A6DF08:
 .done:
     STA.W $0C04,Y                                                        ;A6DF25;
     RTS                                                                  ;A6DF28;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EfficientCollisionDetectionForSamusAt_12_14:
@@ -11301,6 +11335,7 @@ RidleyHitbox_vs_Samus_Collision:
     JMP.W RTL_A6DFB6                                                     ;A6DF5D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_RidleyDamagesSamus_A6DF60:
     JSR.W UNUSED_RidleyDamagesSamus_A6DF66                               ;A6DF60;
     JMP.W RTL_A6DFB6                                                     ;A6DF63;
@@ -11323,6 +11358,7 @@ UNUSED_RidleyDamagesSamus_A6DF66:
 .left:
     STY.W $0A54                                                          ;A6DF86;
     RTS                                                                  ;A6DF89;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EnemyShot_Ridley:
@@ -11404,6 +11440,7 @@ RidleyTail_vs_Samus_Interaction:
     RTS                                                                  ;A6E01A;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProjectileCollision_A6E01B:
     LDX.W $0E54                                                          ;A6E01B;
     LDA.W $0B64                                                          ;A6E01E;
@@ -11457,6 +11494,7 @@ UNUSED_ProjectileCollision_A6E01B:
 
 .return:
     RTS                                                                  ;A6E087;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 KillProjectilesWithRidleyTailTip:
@@ -11488,6 +11526,7 @@ KillProjectilesWithRidleyTailTip:
     RTS                                                                  ;A6E0C1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_TailProjectileCollision_A6E0C2:
     LDA.L $7E207C                                                        ;A6E0C2;
     STA.B $12                                                            ;A6E0C6;
@@ -11526,6 +11565,7 @@ UNUSED_TailProjectileCollision_A6E0C2:
     JSR.W RidleyTail_vs_SamusProjectile_CollisionDetection               ;A6E120;
     BCS TailProjectileCollision                                          ;A6E123;
     RTS                                                                  ;A6E125;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 TailProjectileCollision:
@@ -11557,9 +11597,11 @@ Palette_CeresRidleyInit:
     dw $0000,$7E20,$6560,$2060,$1000,$7940,$5D00,$4CA0                   ;A6E16F;
     dw $3CA0,$43FF,$0113,$000F,$175C,$0299,$01D6,$57E0                   ;A6E17F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palette_Ridley_A6E18F:
     dw $0000,$6BF5,$06E1,$0641,$05A1,$5E5F,$183F,$1014                   ;A6E18F;
     dw $080A,$0404,$4F9F,$3ED8,$2E12,$6F70,$7FFF,$5EE0                   ;A6E19F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_RidleyExplosion_0:
     dw $3800,$56BA,$41B2,$1447,$0403,$4E15,$3570,$24CB                   ;A6E1AF;
@@ -11571,8 +11613,10 @@ Palette_NorfairRidleyInit:
     dw $3800,$6B5A,$5652,$28E7,$1863,$62B5,$4A10,$396B                   ;A6E1CF;
     dw $3129,$43FF,$0113,$000F,$175C,$0299,$01D6,$3BE0                   ;A6E1DF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palette_Ridley_A6E1EF:
     dw $3800                                                             ;A6E1EF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_BabyMetroidCutscene_EndOfInstList:
     dw $6BF5,$06E1,$0641,$05A1,$5E5F,$183F,$1014,$080A                   ;A6E1F1;
@@ -11679,6 +11723,7 @@ Instruction_Ridley_GotoY:
     RTL                                                                  ;A6E4ED;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_RidleyCeres_GotoYIfNotHoldingBaby_A6E4EE:
     LDA.L $7E7836                                                        ;A6E4EE;
     BNE Instruction_Ridley_GotoY                                         ;A6E4F2;
@@ -11693,6 +11738,7 @@ UNUSED_Instruction_RidleyCeres_GotoYIfHoldingBaby_A6E4F8:
     INY                                                                  ;A6E4FE;
     INY                                                                  ;A6E4FF;
     RTL                                                                  ;A6E500;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Inst_RidleyCeres_UpdateSamusPrevPosition_HeldYDisplacement:
@@ -11781,6 +11827,7 @@ UNUSED_InstList_RidleyCeres_FacingRight_Lunging_A6E576:
     dw ExtendedSpritemap_Ridley_FacingRight                              ;A6E59C;
     dw Instruction_Common_Sleep                                          ;A6E59E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_RidleyCeres_FacingLeft_A6E5A0:
     dw Instruction_Ridley_GotoYIfNotFacingLeft                           ;A6E5A0;
     dw UNUSED_InstList_RidleyCeres_FacingRight_A6E5FE                    ;A6E5A2;
@@ -11894,6 +11941,7 @@ UNUSED_InstList_RidleyCeres_FacingRight_HoldingBaby_A6E64E:
     dw $0000,$0002                                                       ;A6E650;
     dw ExtendedSpritemap_Ridley_FacingRight                              ;A6E654;
     dw Instruction_Common_Sleep                                          ;A6E656;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_RidleyCeres_FacingLeft_ExtendLegs:
     dw Instruction_Ridley_GotoYIfNotFacingLeft                           ;A6E658;
@@ -12150,6 +12198,7 @@ InstList_Ridley_FacingRight_Fireballing_1:
     dw ExtendedSpritemap_Ridley_FacingRight                              ;A6E824;
     dw Instruction_Common_Sleep                                          ;A6E826;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpawnUnusedEnemyProjectiles_A6E828:
     LDA.W #$0000                                                         ;A6E828;
     JSL.L UNUSED_SpawnUnusedEnemyProjectile_A6E840                       ;A6E82B;
@@ -12166,6 +12215,7 @@ UNUSED_SpawnUnusedEnemyProjectile_A6E840:
     JSL.L SpawnEnemyProjectileY_ParameterA_XGraphics                     ;A6E847;
     PLY                                                                  ;A6E84B;
     RTL                                                                  ;A6E84C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_Ridley_CalculateFireballAngleAndXYSpeeds:
@@ -12528,6 +12578,7 @@ Hitbox_Ridley_FacingLeft_Torso:
     dw RidleyHitbox_vs_Samus_Collision                                   ;A6EB71;
     dw EnemyShot_Ridley                                                  ;A6EB73;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_Ridley_FacingLeft_A6EB75:
     dw $0001,$FFF0,$FFEC,$000C,$0015                                     ;A6EB75;
     dw RidleyHitbox_vs_Samus_Collision                                   ;A6EB7F;
@@ -12537,6 +12588,7 @@ UNUSED_Hitbox_Ridley_FacingLeft_A6EB83:
     dw $0001,$FFF0,$FFEC,$000C,$0015                                     ;A6EB83;
     dw RidleyHitbox_vs_Samus_Collision                                   ;A6EB8D;
     dw EnemyShot_Ridley                                                  ;A6EB8F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_Ridley_FacingForward:
     dw $0002,$FFF0,$FFE0,$0010,$0022                                     ;A6EB91;
@@ -12595,6 +12647,7 @@ Hitbox_Ridley_FacingRight_Torso:
     dw RidleyHitbox_vs_Samus_Collision                                   ;A6EC3B;
     dw EnemyShot_Ridley                                                  ;A6EC3D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_Ridley_FacingRight_A6EC3F:
     dw $0001,$FFF3,$FFEA,$000E,$0015                                     ;A6EC3F;
     dw RidleyHitbox_vs_Samus_Collision                                   ;A6EC49;
@@ -12604,6 +12657,7 @@ UNUSED_Hitbox_Ridley_FacingRight_A6EC4D:
     dw $0001,$FFF3,$FFEA,$000E,$0015                                     ;A6EC4D;
     dw RidleyHitbox_vs_Samus_Collision                                   ;A6EC57;
     dw EnemyShot_Ridley                                                  ;A6EC59;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Ridley_FacingLeft_HeadNeck_MouthClosed:
     dw $000C,$01E4                                                       ;A6EC5B;

--- a/src/bank_A7.asm
+++ b/src/bank_A7.asm
@@ -169,6 +169,7 @@ Instruction_CommonA7_CallFunctionInY_WithA:
     RTL                                                                  ;A780B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA7_CallExternalFunctionInY_A780B5:
     LDA.W $0000,Y                                                        ;A780B5;
     STA.B $12                                                            ;A780B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA7_CallExternalFunctionInY_WithA_A780CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A780EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA7_GotoY:
@@ -423,9 +425,11 @@ Palette_Kraid:
     dw $3800,$559D,$1816,$100D,$4B9F,$3F37,$36D0,$2E69                   ;A78687;
     dw $2608,$1DA6,$1125,$08C5,$0003,$6318,$7FFF,$0000                   ;A78697;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palette_Kraid_A786A7:
     dw $3800,$559D,$1816,$100D,$4B9F,$3F37,$36D0,$2E69                   ;A786A7;
     dw $2608,$1DA6,$1125,$08C5,$0003,$6318,$7FFF,$0000                   ;A786B7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_KraidRoomBackground:
     dw $0400,$2D6B,$2D6B,$2D6B,$1986,$14C2,$0840,$0400                   ;A786C7;
@@ -746,6 +750,7 @@ InstList_KraidFoot_KraidIsBig_WalkingBackwards_1:
     dw Instruction_Common_GotoY                                          ;A78939;
     dw InstList_KraidFoot_KraidIsBig_WalkingBackwards_0                  ;A7893B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_KraidFoot_WalkingBackwards_Fast_A7893D:
     dw Instruction_Kraid_NOP_A7B633                                      ;A7893D;
     dw UNUSED_Instruction_Kraid_MoveRight_A7B683                         ;A7893F;
@@ -838,6 +843,7 @@ UNUSED_InstList_KraidFoot_WalkingBackwards_Fast_A7893D:
     dw ExtendedSpritemap_KraidFoot_1                                     ;A789ED;
     dw Instruction_Common_GotoY                                          ;A789EF;
     dw UNUSED_InstList_KraidFoot_WalkingBackwards_Fast_A7893D            ;A789F1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_KraidArm_Normal_0:
     dw $0006                                                             ;A789F3;
@@ -1015,6 +1021,7 @@ InstList_KraidNail:
     dw Instruction_Common_GotoY                                          ;A78B2A;
     dw InstList_KraidNail                                                ;A78B2C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_KraidArm_A78B2E:
     dw $0002,$0000,$0000                                                 ;A78B2E;
     dw Spritemap_KraidArm_General_A                                      ;A78B34;
@@ -1157,6 +1164,7 @@ UNUSED_ExtendedSpritemap_KraidArm_A78C62:
     dw $0001,$0000,$0000                                                 ;A78C62;
     dw Spritemap_KraidArm_General_B                                      ;A78C68;
     dw Hitbox_KraidArm_10                                                ;A78C6A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_KraidLint_KraidIsBig:
     dw $0005,$01F4                                                       ;A78C6C;
@@ -1171,6 +1179,7 @@ ExtendedSpritemap_KraidLint_KraidIsBig:
     db $F8                                                               ;A78C84;
     dw $21A9                                                             ;A78C85;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_KraidFoot_A78C87:
     dw $0001,$0000,$0000                                                 ;A78C87;
     dw UNUSED_Spritemap_KraidFoot_A794DA                                 ;A78C8D;
@@ -1212,6 +1221,7 @@ UNUSED_ExtendedSpritemap_KraidFoot_A78CD9:
     dw $0001,$0000,$0000                                                 ;A78CD9;
     dw UNUSED_Spritemap_KraidFoot_A796CB                                 ;A78CDF;
     dw UNUSED_Hitbox_KraidFoot_A79461                                    ;A78CE1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_KraidFoot_0:
     dw $0002,$0008,$0028                                                 ;A78CE3;
@@ -1849,10 +1859,12 @@ Hitbox_KraidLint:
     dw EnemyTouch_KraidArm_KraidFoot_Normal                              ;A792BF;
     dw RTL_A794B5                                                        ;A792C1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_KraidFoot:
     dw $0001,$FFF8,$FFF8,$0007,$0007                                     ;A792C3;
     dw EnemyTouch_KraidArm_KraidFoot_Normal                              ;A792CD;
     dw RTL_A794B5                                                        ;A792CF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_KraidArm_0:
     dw $0002,$FFF3,$FFF5,$FFFD,$FFFB                                     ;A792D1;
@@ -1984,10 +1996,12 @@ Hitbox_KraidFoot:
     dw EnemyTouch_KraidArm_KraidFoot_Normal                              ;A7945D;
     dw RTL_A794B5                                                        ;A7945F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_KraidFoot_A79461:
     dw $0001,$FFFE,$FFFD,$0002,$0003                                     ;A79461;
     dw EnemyTouch_KraidArm_KraidFoot_Normal                              ;A7946B;
     dw RTL_A794B5                                                        ;A7946D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_KraidArm_Dying_PreparingToLungeForward_0:
     dw $0001,$FFC0,$FFD0,$FFE0,$FFF0                                     ;A7946F;
@@ -2046,6 +2060,7 @@ EnemyShot_KraidArm:
     RTL                                                                  ;A794C3;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_KraidLint_A794C4:
     dw $0004,$0000                                                       ;A794C4;
     db $08                                                               ;A794C8;
@@ -2061,6 +2076,7 @@ UNUSED_Spritemap_KraidFoot_A794DA:
     dw $0001,$81F8                                                       ;A794DA;
     db $F8                                                               ;A794DE;
     dw $21A9                                                             ;A794DF;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_KraidArm_General_0:
     dw $0001,$81F2                                                       ;A794E1;
@@ -2103,12 +2119,14 @@ Spritemap_KraidArm_General_6:
     db $F4                                                               ;A7951E;
     dw $F12A                                                             ;A7951F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_KraidArm_General_A79521:
     dw $0002,$01FC                                                       ;A79521;
     db $F2                                                               ;A79525;
     dw $F139,$01FC                                                       ;A79526;
     db $FA                                                               ;A7952A;
     dw $F138                                                             ;A7952B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_KraidArm_General_7:
     dw $0002,$01FA                                                       ;A7952D;
@@ -2129,6 +2147,7 @@ Spritemap_KraidArm_General_9:
     db $FE                                                               ;A79549;
     dw $313E                                                             ;A7954A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_KraidArm_General_A7954C:
     dw $0001,$81FC                                                       ;A7954C;
     db $FC                                                               ;A79550;
@@ -2152,6 +2171,7 @@ UNUSED_Spritemap_KraidArm_General_A79566:
     dw $F13E,$01FD                                                       ;A7956B;
     db $F2                                                               ;A7956F;
     dw $713E                                                             ;A79570;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_KraidArm_General_A:
     dw $0001,$81F4                                                       ;A79572;
@@ -2308,6 +2328,7 @@ Spritemap_KraidFoot_4:
     db $FC                                                               ;A796C1;
     dw $31D4                                                             ;A796C2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_KraidFoot_A796C4:
     dw $0001,$81F8                                                       ;A796C4;
     db $F8                                                               ;A796C8;
@@ -2317,6 +2338,7 @@ UNUSED_Spritemap_KraidFoot_A796CB:
     dw $0001,$01FC                                                       ;A796CB;
     db $FC                                                               ;A796CF;
     dw $21D2                                                             ;A796D0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Kraid_Roar_0:
     dw $000A                                                             ;A796D2;
@@ -2661,6 +2683,7 @@ Tilemap_KraidHead_3:
     dw $3C70,$3C71,$3D42,$0338,$0338,$0338,$0338,$0338                   ;A7A3A8;
     dw $0338,$0338,$0338,$0338,$0338,$0338,$0338,$0338                   ;A7A3B8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_KraidArm_A7A3C8:
     dw $0002,$0000,$0000                                                 ;A7A3C8;
     dw Spritemap_KraidArm_RisingSinking_A                                ;A7A3CE;
@@ -2740,6 +2763,7 @@ UNUSED_ExtendedSpritemap_KraidArm_A7A46A:
     dw $0000,$0000                                                       ;A7A474;
     dw Spritemap_KraidArm_RisingSinking_9                                ;A7A478;
     dw Hitbox_KraidArm_A                                                 ;A7A47A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_KraidArm_RisingSinking_0:
     dw $0001,$81F2                                                       ;A7A47C;
@@ -2806,6 +2830,7 @@ Spritemap_KraidArm_RisingSinking_A:
     db $F4                                                               ;A7A4DF;
     dw $212C                                                             ;A7A4E0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_KraidArm_A7A4E2:
     dw $0001,$0000,$0000                                                 ;A7A4E2;
     dw Spritemap_KraidArm_RisingSinking_D                                ;A7A4E8;
@@ -2820,6 +2845,7 @@ UNUSED_ExtendedSpritemap_KraidArm_A7A4F6:
     dw $0001,$0000,$0000                                                 ;A7A4F6;
     dw Spritemap_KraidArm_RisingSinking_B                                ;A7A4FC;
     dw Hitbox_KraidArm_10                                                ;A7A4FE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_KraidArm_RisingSinking_B:
     dw $0003,$81F4                                                       ;A7A500;
@@ -2935,6 +2961,7 @@ Spritemap_KraidLint_Initial:
     db $08                                                               ;A7A5F7;
     dw $11A9                                                             ;A7A5F8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_KraidLint_A7A5FA:
     dw $0004,$0000                                                       ;A7A5FA;
     db $08                                                               ;A7A5FE;
@@ -2950,6 +2977,7 @@ UNUSED_Spritemap_KraidLint_A7A610:
     dw $0001,$81F8                                                       ;A7A610;
     db $F8                                                               ;A7A614;
     dw $11A9                                                             ;A7A615;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_KraidNail_0:
     dw $0002,$C3F4                                                       ;A7A617;
@@ -3121,17 +3149,21 @@ KraidLint_InitialFunctionTimers_bottom:
 KraidForwardsSpeed:
     dw $0003                                                             ;A7A91C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_KraidConstant_A7A91E:
     dw $0005                                                             ;A7A91E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 KraidBackwardsSpeed:
     dw $0003                                                             ;A7A920;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_KraidBackwardsFastSpeed_A7A922:
     dw $0004                                                             ;A7A922;
 
 UNUSED_KraidConstant_A7A924:
     dw $0110                                                             ;A7A924;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 KraidLint_XSubSpeed:
     dw $8000                                                             ;A7A926;
@@ -3139,8 +3171,10 @@ KraidLint_XSubSpeed:
 KraidLint_XSpeed:
     dw $0003                                                             ;A7A928;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_REP30_A7A92A:
     REP #$30                                                             ;A7A92A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 CheckIfKraidHasDied:
     PHX                                                                  ;A7A92C;
@@ -4327,6 +4361,7 @@ KraidBody_vs_Projectile_CollisionHandling:
     BRA .hit                                                             ;A7B267;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HandleProjectileDamageAndSound:
     PHX                                                                  ;A7B269;
     PHY                                                                  ;A7B26A;
@@ -4439,6 +4474,7 @@ UNUSED_HandleProjectileDamageAndSound:
     PLY                                                                  ;A7B334;
     PLX                                                                  ;A7B335;
     RTS                                                                  ;A7B336;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 KraidPaletteHandling:
@@ -4679,6 +4715,7 @@ Instruction_Kraid_XPositionPlus3:
     RTL                                                                  ;A7B682;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_Kraid_MoveRight_A7B683:
     PHX                                                                  ;A7B683;
     PHY                                                                  ;A7B684;
@@ -4712,6 +4749,7 @@ UNUSED_Instruction_Kraid_MoveRight_A7B683:
     LDA.W $0F7A                                                          ;A7B6B7;
     STA.W $10BA                                                          ;A7B6BA;
     BRA .return                                                          ;A7B6BD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_Kraid_KraidShot_InitializeEyeGlowing:
@@ -5441,6 +5479,7 @@ Function_KraidMainLoop_AttackingWithMouthOpen:
 .rockSpitXVelocities:
     dw $FC00,$FC40,$FB40,$FB80,$FB40,$FC00,$FB80,$FC40                   ;A7BC65;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_KraidFoot_LungeForwardIfSamusIsNotInvincible_A7BC75:
     LDA.W $10D2                                                          ;A7BC75;
     CMP.W #InstList_KraidFoot_LungeForward_1                             ;A7BC78;
@@ -5484,6 +5523,7 @@ UNUSED_Kraid_FireLintAfterAFrames_A7BCB5:
     ORA.W #$0100                                                         ;A7BCC8;
     STA.W $0F86,X                                                        ;A7BCCB;
     RTS                                                                  ;A7BCCE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 EnemyTouch_KraidNail:
@@ -5956,6 +5996,7 @@ Function_Kraid_GetBig_ReleaseCamera:
     RTL                                                                  ;A7C0BC;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_CrumbleFirstSectionOfKraidsSpikeFloor_A7C0BD:
     JSL.L Spawn_Hardcoded_PLM                                            ;A7C0BD;
     db $06,$1B                                                           ;A7C0C1;
@@ -6025,6 +6066,7 @@ UNUSED_CrumbleFirstSectionOfKraidsSpikeFloor_A7C0BD:
     db $1A,$1B                                                           ;A7C163;
     dw PLMEntries_crumbleKraidSpikeBlocks                                ;A7C165;
     RTS                                                                  ;A7C167;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 SpawnPLMToClearTheCeiling:
@@ -6041,6 +6083,7 @@ SpawnPLMToClearTheSpikes:
     RTS                                                                  ;A7C179;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ClearSomeOfTheSpikeBlocks_A7C17A:
     JSL.L Spawn_Hardcoded_PLM                                            ;A7C17A;
     db $0B,$1B                                                           ;A7C17E;
@@ -6091,6 +6134,7 @@ UNUSED_ClearSomeOfTheSpikeBlocks_A7C17A:
     db $1A,$1B                                                           ;A7C1F6;
     dw PLMEntries_clearKraidSpikeBlocks                                  ;A7C1F8;
     RTS                                                                  ;A7C1FA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 UnpauseHook_KraidIsDead:
@@ -6375,6 +6419,7 @@ KraidDeath_FadeOutBackground:
     RTL                                                                  ;A7C456;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ProcessKraidInstruction_WithNoASMInstructions_A7C457:
     LDA.W $0FAC                                                          ;A7C457;
     BEQ .return                                                          ;A7C45A;
@@ -6419,6 +6464,7 @@ UNUSED_ProcessKraidInstruction_WithNoASMInstructions_A7C457:
 
 .return:
     RTS                                                                  ;A7C4A3;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 KraidDeath_UpdateBG2TilemapTopHalf:
@@ -7098,9 +7144,11 @@ Palette_Phantoon:
     dw $3800,$7FFF,$7EC0,$6DE0,$54E0,$0000,$0000,$0000                   ;A7CA01;
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A7CA11;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palette_Phantoon_A7CA21:
     dw $0000,$477B,$2E52,$00C6,$0063,$3AB5,$2210,$116B                   ;A7CA21;
     dw $0508,$7FFF,$36B5,$19AD,$0929,$381D,$1814,$000A                   ;A7CA31;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Phantoon_FadeOutTarget:
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A7CA41;
@@ -7182,6 +7230,7 @@ InstList_Phantoon_Eye_Open:
     dw SetupEyeOpenPhantoonState                                         ;A7CC65;
     dw Instruction_Common_Sleep                                          ;A7CC67;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Phantoon_Eye_Open_IgnoringSamus_A7CC69:
     dw $000A                                                             ;A7CC69;
     dw ExtendedSpritemap_Phantoon_Eye_Opening                            ;A7CC6B;
@@ -7192,6 +7241,7 @@ UNUSED_InstList_Phantoon_Eye_Open_IgnoringSamus_A7CC69:
     dw Instruction_Common_CallFunctionInY                                ;A7CC75;
     dw PlayPhantoonMaterializationSFX                                    ;A7CC77;
     dw Instruction_CommonA7_Sleep                                        ;A7CC79;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Phantoon_Eye_Closed:
     dw $0001                                                             ;A7CC7B;
@@ -7362,8 +7412,10 @@ Phantoon_ReverseFigure8_SpeedCaps_Stage1Max:
 Phantoon_ReverseFigure8_SpeedCaps_Stage2Min:
     dw $0000                                                             ;A7CD8D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Phantoon_A7CD8F:
     dw $8000,$0000,$000B,$8000,$0000,$FFF5                               ;A7CD8F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 WavyPhantoonConstants_Intro_amplitudeDelta:
     dw $0040                                                             ;A7CD9B;
@@ -8446,6 +8498,7 @@ Function_Phantoon_FightIntro_WavyFadeIn:
     RTS                                                                  ;A7D580;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Function_Phantoon_FightIntro_A7D581:
     LDX.W #$01FE                                                         ;A7D581;
     LDA.W #$0000                                                         ;A7D584;
@@ -8458,6 +8511,7 @@ UNUSED_Function_Phantoon_FightIntro_A7D581:
     LDA.W #Function_Phantoon_FightIntro_PickFirstPattern                 ;A7D58F;
     STA.W $0FB2,X                                                        ;A7D592;
     RTS                                                                  ;A7D595;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_Phantoon_FightIntro_PickFirstPattern:
@@ -9827,6 +9881,7 @@ ExtendedSpritemap_Phantoon_Eyeball_LookingUpRight:
     dw ExtendedTilemap_Phantoon_Eyeball_LookingUpRight                   ;A7DF79;
     dw Hitbox_Phantoon_0                                                 ;A7DF7B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_Phantoon_Tentacles_A7DF7D:
     dw $0002,$0000,$0000                                                 ;A7DF7D;
     dw ExtendedTilemap_Phantoon_Tentacle_Left_0                          ;A7DF83;
@@ -9850,6 +9905,7 @@ UNUSED_ExtendedSpritemap_Phantoon_Tentacles_A7DFA1:
     dw $0000,$0000                                                       ;A7DFAB;
     dw ExtendedTilemap_Phantoon_Tentacle_Right_2                         ;A7DFAF;
     dw Hitbox_Phantoon_0                                                 ;A7DFB1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_Phantoon_Tentacles_0:
     dw $0002,$0000,$0000                                                 ;A7DFB3;
@@ -9890,19 +9946,23 @@ ExtendedSpritemap_Phantoon_Mouth_SpawningFlame_1:
     dw ExtendedTilemap_Phantoon_Mouth_2                                  ;A7E003;
     dw Hitbox_Phantoon_0                                                 ;A7E005;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_Phantoon_Mouth_SpawningFlame_A7E007:
     dw $0001,$0000,$0000                                                 ;A7E007;
     dw ExtendedTilemap_Phantoon_Mouth_0                                  ;A7E00D;
     dw Hitbox_Phantoon_0                                                 ;A7E00F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 RTL_A7E011:
     RTL                                                                  ;A7E011;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitbox_Phantoon_A7E012:
     dw $0001,$FFF7,$FFF0,$0008,$0010                                     ;A7E012;
     dw EnemyTouch_Phantoon                                               ;A7E01C;
     dw EnemyShot_Phantoon                                                ;A7E01E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitbox_Phantoon_0:
     dw $0001,$0000,$0000,$0000,$0000                                     ;A7E020;
@@ -9931,6 +9991,7 @@ Hitbox_Phantoon_2:
     dw EnemyTouch_Phantoon                                               ;A7E076;
     dw EnemyShot_Phantoon                                                ;A7E078;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_PhantoonFlame_A7E07A:
     dw $0002,$81F8                                                       ;A7E07A;
     db $00                                                               ;A7E07E;
@@ -9958,6 +10019,7 @@ UNUSED_Spritemap_PhantoonFlame_A7E09E:
     dw $610C,$81F0                                                       ;A7E0A3;
     db $F8                                                               ;A7E0A7;
     dw $210C                                                             ;A7E0A8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedTilemap_Phantoon_Body:
     dw $FFFE,$2000,$000A,$2338,$2338,$2338,$3D32,$3D33                   ;A7E0AA;
@@ -11608,10 +11670,12 @@ InstList_Dachora_Blinking_FacingLeft:
     dw Instruction_Common_GotoY                                          ;A7F3ED;
     dw InstList_Dachora_Blinking_FacingLeft                              ;A7F3EF;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Dachora_ChargeShinespark_FacingLeft_A7F3F1:
     dw $0001                                                             ;A7F3F1;
     dw Spritemap_Dachora_6                                               ;A7F3F3;
     dw Instruction_Common_Sleep                                          ;A7F3F5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Dachora_Echo_FacingLeft:
     dw $000A                                                             ;A7F3F7;

--- a/src/bank_A8.asm
+++ b/src/bank_A8.asm
@@ -169,6 +169,7 @@ Instruction_CommonA8_CallFunctionInY_WithA:
     RTL                                                                  ;A880B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA8_CallExternalFunctionInY_A880B5:
     LDA.W $0000,Y                                                        ;A880B5;
     STA.B $12                                                            ;A880B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA8_CallExternalFunctionInY_WithA_A880CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A880EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA8_GotoY:
@@ -1173,6 +1175,7 @@ Spritemap_Evir_5:
     db $08                                                               ;A88C70;
     dw $2125                                                             ;A88C71;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Evir_A88C73:
     dw $0009,$81FE                                                       ;A88C73;
     db $FB                                                               ;A88C77;
@@ -1193,6 +1196,7 @@ UNUSED_Spritemap_Evir_A88C73:
     dw $2126,$01FE                                                       ;A88C9B;
     db $08                                                               ;A88C9F;
     dw $2125                                                             ;A88CA0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Evir_6:
     dw $0005,$0000                                                       ;A88CA2;
@@ -1257,6 +1261,7 @@ Spritemap_Evir_A:
     db $FC                                                               ;A88D21;
     dw $2124                                                             ;A88D22;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Evir_A88D24:
     dw $0006,$01FE                                                       ;A88D24;
     db $F4                                                               ;A88D28;
@@ -1286,6 +1291,7 @@ UNUSED_Spritemap_Evir_A88D44:
     dw $2121,$01FA                                                       ;A88D5D;
     db $FC                                                               ;A88D61;
     dw $2120                                                             ;A88D62;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Evir_B:
     dw $0004,$0000                                                       ;A88D64;
@@ -1429,6 +1435,7 @@ Spritemap_Evir_12:
     db $08                                                               ;A88E98;
     dw $6125                                                             ;A88E99;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Evir_A88E9B:
     dw $0009,$81F2                                                       ;A88E9B;
     db $FB                                                               ;A88E9F;
@@ -1449,6 +1456,7 @@ UNUSED_Spritemap_Evir_A88E9B:
     dw $6126,$01FA                                                       ;A88EC3;
     db $08                                                               ;A88EC7;
     dw $6125                                                             ;A88EC8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Evir_13:
     dw $0005,$01F8                                                       ;A88ECA;
@@ -1513,6 +1521,7 @@ Spritemap_Evir_17:
     db $F4                                                               ;A88F49;
     dw $6124                                                             ;A88F4A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Evir_A88F4C:
     dw $0006,$01FA                                                       ;A88F4C;
     db $F4                                                               ;A88F50;
@@ -1542,6 +1551,7 @@ UNUSED_Spritemap_Evir_A88F6C:
     dw $6121,$01FE                                                       ;A88F85;
     db $FC                                                               ;A88F89;
     dw $6120                                                             ;A88F8A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Eye:
     dw $3800,$72B2,$71C7,$2461,$1840,$7A8E,$660B,$4D03                   ;A88F8C;
@@ -2890,6 +2900,7 @@ Palette_Coven:
     dw $3800,$57FF,$42F7,$0929,$00A5,$4F5A,$36B5,$2610                   ;A899AC;
     dw $1DCE,$01DF,$001F,$0018,$000A,$06B9,$00EA,$0045                   ;A899BC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Coven_BlackPalettes_A899CC:
     dw $3800,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A899CC;
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A899DC;
@@ -2903,6 +2914,7 @@ UNUSED_Coven_BlackPalettes_A899CC:
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A89A5C;
     dw $3800,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A89A6C;
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A89A7C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Coven:
     dw $0010                                                             ;A89A8C;
@@ -3746,11 +3758,13 @@ YappingMawSamusOffsets_X_UpRight:
 YappingMawSamusOffsets_Y_UpRight:
     dw $FFF8                                                             ;A8A0AD;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_YappingMawSamusOffsets_X_Right_A8A0AF:
     dw $0010                                                             ;A8A0AF;
 
 UNUSED_YappingMawSamusOffsets_Y_Right_A8A0B1:
     dw $0000                                                             ;A8A0B1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 YappingMawSamusOffsets_X_DownRight:
     dw $0008                                                             ;A8A0B3;
@@ -3770,11 +3784,13 @@ YappingMawSamusOffsets_X_DownLeft:
 YappingMawSamusOffsets_Y_DownLeft:
     dw $0008                                                             ;A8A0BD;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_YappingMawSamusOffsets_X_Left_A8A0BF:
     dw $FFF0                                                             ;A8A0BF;
 
 UNUSED_YappingMawSamusOffsets_Y_Left_A8A0C1:
     dw $0000                                                             ;A8A0C1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 YappingMawSamusOffsets_X_UpLeft:
     dw $FFF8                                                             ;A8A0C3;
@@ -5482,6 +5498,7 @@ Instruction_Magdollite_ShiftLeft8Pixels_Up4Pixels_Left_dup:
     RTL                                                                  ;A8AF31;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Magdollite_RestoreXYPositions_A8AF32:
     LDX.W $0E54                                                          ;A8AF32;
     LDA.L $7E7824,X                                                      ;A8AF35;
@@ -5489,6 +5506,7 @@ UNUSED_Magdollite_RestoreXYPositions_A8AF32:
     LDA.L $7E7826,X                                                      ;A8AF3C;
     STA.W $0F7E,X                                                        ;A8AF40;
     RTL                                                                  ;A8AF43;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_Magdollite_SetCooldownTimerTo100:
@@ -6186,10 +6204,12 @@ Spritemap_Magdollite_FacingLeft_WidePillarSection:
     db $F8                                                               ;A8B4C5;
     dw $210E                                                             ;A8B4C6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Magdollite_Blank_A8B4C8:
     dw $0001,$81F8                                                       ;A8B4C8;
     db $F8                                                               ;A8B4CC;
     dw $210C                                                             ;A8B4CD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Magdollite_FacingLeft_Head_PokingOutOfLava:
     dw $0003,$0004                                                       ;A8B4CF;
@@ -6268,22 +6288,26 @@ Spritemap_Magdollite_FacingRight_Hand_FingersCurled:
     db $F8                                                               ;A8B55B;
     dw $6100                                                             ;A8B55C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Magdollite_FacingRight_PillarCap_A8B55E:
     dw $0002,$01F8                                                       ;A8B55E;
     db $FC                                                               ;A8B562;
     dw $6125,$0000                                                       ;A8B563;
     db $FC                                                               ;A8B567;
     dw $6124                                                             ;A8B568;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Magdollite_FacingRight_WidePillarSection:
     dw $0001,$81F8                                                       ;A8B56A;
     db $F8                                                               ;A8B56E;
     dw $610E                                                             ;A8B56F;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Magdollite_FacingRight_NarrowPillar_A8B571:
     dw $0001,$81F8                                                       ;A8B571;
     db $F8                                                               ;A8B575;
     dw $610C                                                             ;A8B576;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_Magdollite_FacingRight_Head_PokingOutOfLava:
     dw $0003,$01F4                                                       ;A8B578;
@@ -6403,9 +6427,11 @@ Palette_Beetom:
     dw $3800,$57FF,$42F7,$158C,$00A5,$4F5A,$36B5,$2610                   ;A8B65E;
     dw $1DCE,$1CDF,$4FE0,$3B20,$2A20,$1097,$6BDF,$042E                   ;A8B66E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_BeetomEyeColors_A8B67E:
     dw $4FE0,$3B20,$2A20,$3BE0,$2680,$1580,$2740,$11E0                   ;A8B67E;
     dw $00E0,$12A0,$0140,$0040                                           ;A8B68E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Beetom_Crawling_FacingLeft_0:
     dw Instruction_Common_DisableOffScreenProcessing                     ;A8B696;
@@ -6434,6 +6460,7 @@ InstList_Beetom_Hop_FacingLeft:
     dw Spritemap_Beetom_0                                                ;A8B6BC;
     dw Instruction_Common_Sleep                                          ;A8B6BE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Beetom_SmallHop_FacingLeft_A8B6C0:
     dw Instruction_Common_EnableOffScreenProcessing                      ;A8B6C0;
     dw $0004                                                             ;A8B6C2;
@@ -6441,6 +6468,7 @@ UNUSED_InstList_Beetom_SmallHop_FacingLeft_A8B6C0:
     dw $0001                                                             ;A8B6C6;
     dw Spritemap_Beetom_0                                                ;A8B6C8;
     dw Instruction_Common_Sleep                                          ;A8B6CA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Beetom_DrainingSamus_FacingLeft_0:
     dw $0005                                                             ;A8B6CC;
@@ -6492,6 +6520,7 @@ InstList_Beetom_Hop_FacingRight:
     dw Spritemap_Beetom_B                                                ;A8B718;
     dw Instruction_Common_Sleep                                          ;A8B71A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Beetom_SmallHop_FacingRight_A8B71C:
     dw Instruction_Common_EnableOffScreenProcessing                      ;A8B71C;
     dw $0004                                                             ;A8B71E;
@@ -6499,6 +6528,7 @@ UNUSED_InstList_Beetom_SmallHop_FacingRight_A8B71C:
     dw $0001                                                             ;A8B722;
     dw Spritemap_Beetom_B                                                ;A8B724;
     dw Instruction_CommonA8_Sleep                                        ;A8B726;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Beetom_DrainingSamus_FacingRight_0:
     dw $0005                                                             ;A8B728;
@@ -11371,8 +11401,10 @@ InstList_Alcoon_FacingRight_Airborne_LookingForward:
 AlcoonConstants_XThresholdToEmerge:
     dw $0050                                                             ;A8DCC7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AlcoonConstants_A8DCC9:
     dw $0040                                                             ;A8DCC9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 AlcoonConstants_XThresholdToHide:
     dw $0070                                                             ;A8DCCB;
@@ -11773,9 +11805,11 @@ RTL_A8DF9C:
     RTL                                                                  ;A8DF9C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_NormalEnemyShotAI_A8DF9D:
     JSL.L NormalEnemyShotAI                                              ;A8DF9D;
     RTL                                                                  ;A8DFA1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Spritemap_Alcoon_FacingLeft_FrontFootForward:
@@ -12068,6 +12102,7 @@ Spritemap_Alcoon_FacingRight_LookingUp:
     db $F8                                                               ;A8E211;
     dw $610A                                                             ;A8E212;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Alcoon_FireballProjectile_0_A8E214:
     dw $0001,$01FC                                                       ;A8E214;
     db $FC                                                               ;A8E218;
@@ -12087,11 +12122,13 @@ UNUSED_Spritemap_Alcoon_FireballProjectile_3_A8E229:
     dw $0001,$01FC                                                       ;A8E229;
     db $FC                                                               ;A8E22D;
     dw $212D                                                             ;A8E22E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Atomic:
     dw $3800,$7FFF,$56E0,$3180,$18C0,$6BC0,$5EC0,$4A20                   ;A8E230;
     dw $35A0,$7FFF,$039C,$0237,$00D1,$03FF,$0237,$00D1                   ;A8E240;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palettes_Atomic_A8E250:
     dw $3800,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A8E250;
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A8E260;
@@ -12105,6 +12142,7 @@ UNUSED_Palettes_Atomic_A8E250:
     dw $0011,$7FFF,$039C,$0237,$00D1,$03FF,$0237,$00D1                   ;A8E2E0;
     dw $3800,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A8E2F0;
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000,$0000                   ;A8E300;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Atomic_SpinningUpRight:
     dw $0008                                                             ;A8E310;
@@ -12307,6 +12345,7 @@ Function_Atomic_MoveRight:
     RTS                                                                  ;A8E480;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Atomic_GetEnemyIndex_A8E481:
     LDX.W $0E54                                                          ;A8E481;
     RTL                                                                  ;A8E484;
@@ -12315,6 +12354,7 @@ UNUSED_Atomic_GetEnemyIndex_A8E481:
 UNUSED_Atomic_GetEnemyIndex_A8E485:
     LDX.W $0E54                                                          ;A8E485;
     RTL                                                                  ;A8E488;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Spritemap_Atomic_0:
@@ -13050,6 +13090,7 @@ InstList_KihunterWings_FacingRight:
     dw Instruction_Common_GotoY                                          ;A8EA6A;
     dw InstList_KihunterWings_FacingRight                                ;A8EA6C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_KihunterWings_Falling_XFlipped_A8EA6E:
     dw $0010                                                             ;A8EA6E;
     dw Spritemap_Kihunter_6                                              ;A8EA70;
@@ -13061,16 +13102,19 @@ UNUSED_InstList_KihunterWings_Falling_XFlipped_A8EA76:
     dw Spritemap_Kihunter_7                                              ;A8EA78;
     dw Instruction_Common_GotoY                                          ;A8EA7A;
     dw UNUSED_InstList_KihunterWings_Falling_XFlipped_A8EA76             ;A8EA7C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_KihunterWings_Falling:
     dw $0001                                                             ;A8EA7E;
     dw Spritemap_Kihunter_E                                              ;A8EA80;
     dw Instruction_Common_Sleep                                          ;A8EA82;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_KihunterWings_Falling_A8EA84:
     dw $0001                                                             ;A8EA84;
     dw Spritemap_Kihunter_F                                              ;A8EA86;
     dw Instruction_Common_Sleep                                          ;A8EA88;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Kihunter_Hop_FacingLeft:
     dw $0008                                                             ;A8EA8A;

--- a/src/bank_A9.asm
+++ b/src/bank_A9.asm
@@ -169,6 +169,7 @@ Instruction_CommonA9_CallFunctionInY_WithA:
     RTL                                                                  ;A980B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonA9_CallExternalFunctionInY_A980B5:
     LDA.W $0000,Y                                                        ;A980B5;
     STA.B $12                                                            ;A980B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonA9_CallExternalFunctionInY_WithA_A980CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;A980EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonA9_GotoY:
@@ -2254,11 +2256,13 @@ Instruction_MotherBrainBody_MoveBodyUpBy12_ScrollRightBy2:
     JMP.W MoveMotherBrainBodyDownByA_ScrollLeftByX                       ;A995D1;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_MotherBrainBody_MoveBodyRightBy2_A995D4:
     PHX                                                                  ;A995D4;
     LDX.W #$FFFE                                                         ;A995D5;
     LDA.W #$0000                                                         ;A995D8;
     JMP.W MoveMotherBrainBodyDownByA_ScrollLeftByX                       ;A995DB;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_MotherBrainBody_MoveBodyDownBy12_ScrollLeftBy4:
@@ -3147,11 +3151,13 @@ InstList_MotherBrainHead_InitialDummy:
     dw UNUSED_ExtendedSpritemap_MotherBrainBrain_A9A320                  ;A99C15;
     dw Instruction_Common_Sleep                                          ;A99C17;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_MotherBrainHead_A99C19:
     dw $0008                                                             ;A99C19;
     dw Spritemaps_MotherBrain_2                                          ;A99C1B;
     dw $0004                                                             ;A99C1D;
     dw Spritemaps_MotherBrain_1                                          ;A99C1F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_MotherBrainHead_Initial:
     dw $0004                                                             ;A99C21;
@@ -3217,11 +3223,13 @@ InstList_MotherBrainHead_FiringRainbowBeam:
     dw Instruction_MotherBrain_GotoX                                     ;A99C7B;
     dw InstList_MotherBrainHead_FiringRainbowBeam                        ;A99C7D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_MotherBrainHead_A99C7F:
     dw $0001                                                             ;A99C7F;
     dw Spritemaps_MotherBrain_8                                          ;A99C81;
     dw Instruction_MotherBrain_GotoX                                     ;A99C83;
     dw UNUSED_InstList_MotherBrainHead_A99C7F                            ;A99C85;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_MotherBrainHead_Neutral_Phase2_0:
     dw $0004                                                             ;A99C87;
@@ -3281,6 +3289,7 @@ InstList_MotherBrainHead_Neutral_Phase3_1:
     dw Instruction_MotherBrain_GotoX                                     ;A99CDF;
     dw InstList_MotherBrainHead_Neutral_Phase3_0                         ;A99CE1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_MotherBrainHead_Neutral_Phase3_A99CE3:
     dw $0004                                                             ;A99CE3;
     dw Spritemaps_MotherBrain_8                                          ;A99CE5;
@@ -3302,6 +3311,7 @@ UNUSED_InstList_MotherBrainHead_Neutral_Phase3_A99CE3:
     dw $0004                                                             ;A99D07;
     dw Spritemaps_MotherBrain_8                                          ;A99D09;
     dw Instruction_MotherBrainHead_GotoNeutralPhase3                     ;A99D0B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Instruction_MotherBrainHead_MaybeGotoNeutralPhase3:
     LDA.W $05E5                                                          ;A99D0D;
@@ -3309,8 +3319,10 @@ Instruction_MotherBrainHead_MaybeGotoNeutralPhase3:
     CMP.W #$0F40                                                         ;A99D13;
     BRA +                                                                ;A99D16;
 
+if !FEATURE_KEEP_UNREFERENCED
     LDX.W #UNUSED_InstList_MotherBrainHead_Neutral_Phase3_A99CE3         ;A99D18;
     RTS                                                                  ;A99D1B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
   + CMP.W #$0EC0                                                         ;A99D1C;
@@ -4034,6 +4046,7 @@ UNUSED_ExtendedSpritemap_MotherBrainBrain_A9A320:
     dw Spritemaps_MotherBrain_0                                          ;A9A326;
     dw Hitbox_MotherBrainBody_0                                          ;A9A328;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemap_MotherBrainBrain_A9A32A:
     dw $0001,$0000,$0000                                                 ;A9A32A;
     dw Spritemaps_MotherBrain_1                                          ;A9A330;
@@ -4078,6 +4091,7 @@ UNUSED_ExtendedSpritemap_MotherBrainBrain_A9A37A:
     dw $0001,$0000,$0000                                                 ;A9A37A;
     dw Spritemaps_MotherBrain_A                                          ;A9A380;
     dw Hitbox_MotherBrainBody_1                                          ;A9A382;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemap_MotherBrainBrain_DeathBeamMode_0:
     dw $0009,$0012,$003A                                                 ;A9A384;
@@ -4657,6 +4671,7 @@ Spritemaps_MotherBrain_14:
     db $FC                                                               ;A9A8D2;
     dw $2748                                                             ;A9A8D3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_MotherBrain_A9A8D5:
     dw $0006,$801D                                                       ;A9A8D5;
     db $03                                                               ;A9A8D9;
@@ -4705,12 +4720,14 @@ UNUSED_Spritemaps_MotherBrain_A9A91F:
     dw $A76C,$81FD                                                       ;A9A938;
     db $F5                                                               ;A9A93C;
     dw $A75C                                                             ;A9A93D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_MotherBrain_15:
     dw $0001,$81F8                                                       ;A9A93F;
     db $F8                                                               ;A9A943;
     dw $2764                                                             ;A9A944;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_MotherBrain_A9A946:
     dw $0002,$81F8                                                       ;A9A946;
     db $10                                                               ;A9A94A;
@@ -4724,6 +4741,7 @@ UNUSED_Spritemaps_MotherBrain_A9A952:
     dw $278A,$81F7                                                       ;A9A957;
     db $00                                                               ;A9A95B;
     dw $2781                                                             ;A9A95C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_MotherBrain_16:
     dw $0004,$01FB                                                       ;A9A95E;
@@ -4762,6 +4780,7 @@ ExtendedTilemaps_MotherBrain_0:
     dw $2338,$2338,$2338,$22C0,$0004,$2338,$2338,$31EE                   ;A9AA3A;
     dw $31EF,$FFFF                                                       ;A9AA4A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedTilemaps_MotherBrain_A9AA4E:
     dw $FFFE,$2084,$0002,$2338,$2338,$20C2,$0003,$2338                   ;A9AA4E;
     dw $2338,$2338,$2102,$0003,$2338,$2338,$2338,$2140                   ;A9AA5E;
@@ -4773,6 +4792,7 @@ UNUSED_ExtendedTilemaps_MotherBrain_A9AA4E:
     dw $2240,$0007,$2338,$2338,$2338,$2338,$2338,$2338                   ;A9AABE;
     dw $2338,$2282,$0006,$2338,$2338,$2338,$2338,$2338                   ;A9AACE;
     dw $2338,$22C4,$0002,$2338,$2338,$FFFF                               ;A9AADE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedTilemaps_MotherBrain_1:
     dw $FFFE,$2006,$000B,$2338,$2338,$3167,$3168,$3169                   ;A9AAEA;
@@ -7539,6 +7559,7 @@ Function_MotherBrainBody_Walking_RetreatSlowly:
     JMP.W SetMotherBrainWalkingFunctionToTryToInchForward                ;A9C2E2;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Function_MotherBrainBody_Walking_Crouch_A9C2E5:
     JSR.W MakeMotherBrainCrouch                                          ;A9C2E5;
     BCC UNUSED_Function_MotherBrainBody_Walking_Crouch_return_A9C2F8     ;A9C2E8;
@@ -7563,6 +7584,7 @@ UNUSED_Function_MotherBrainBody_Walking_StandUp_A9C30B:
     JSR.W MakeMotherBrainStandUp                                         ;A9C30B;
     BCC UNUSED_Function_MotherBrainBody_Walking_Crouch_return_A9C2F8     ;A9C30E;
     LDA.W #$00C0                                                         ;A9C310; fallthrough to SetMotherBrainWalkingFunctionToTryToInchForward
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SetMotherBrainWalkingFunctionToTryToInchForward:
     STA.L $7E780E                                                        ;A9C313;
@@ -7753,6 +7775,7 @@ GetSineMathInA_A9C46C:
     RTL                                                                  ;A9C48D;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_AddADividedBy100ToEnemyXPosition_A9C48E:
     SEP #$20                                                             ;A9C48E;
     CLC                                                                  ;A9C490;
@@ -7767,6 +7790,7 @@ UNUSED_AddADividedBy100ToEnemyXPosition_A9C48E:
   + ADC.W $0F7A,X                                                        ;A9C4A2;
     STA.W $0F7A,X                                                        ;A9C4A5;
     RTS                                                                  ;A9C4A8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 AddADividedBy100ToEnemyYPosition:
@@ -8001,6 +8025,7 @@ MakeMotherBrainWalkForwards:
     dw InstList_MotherBrainBody_WalkingForwards_Slow                     ;A9C626;
     dw InstList_MotherBrainBody_WalkingForwards_ReallySlow               ;A9C628;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_MakeMotherBrainWalkBackwards_A9C62A:
     CMP.W $0F7A                                                          ;A9C62A;
     BPL .returnCarrySet                                                  ;A9C62D;
@@ -8020,6 +8045,7 @@ UNUSED_MakeMotherBrainWalkBackwards_A9C62A:
 .returnCarrySet:
     SEC                                                                  ;A9C645;
     RTS                                                                  ;A9C646;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 MakeMotherBrainWalkBackwards:
@@ -9393,6 +9419,7 @@ UNSUED_SetInvalidRoomPaletteInstructionList_A9D151:
     RTS                                                                  ;A9D15F;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_HandleMotherBrainsPalette_A9D160:
     LDA.W #$781C                                                         ;A9D160;
     JSR.W HandleRoomPaletteInstList                                      ;A9D163;
@@ -9414,6 +9441,7 @@ UNUSED_HandleMotherBrainsPalette_A9D160:
 
 .return:
     RTS                                                                  ;A9D191;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 HandleRoomPaletteInstList:
@@ -12738,6 +12766,7 @@ Spritemap_CorpseSkree_2:
     db $F4                                                               ;A9EDF4;
     dw $310E                                                             ;A9EDF5;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemap_Corpse_A9EDF7:
     dw $000A,$000C                                                       ;A9EDF7;
     db $FC                                                               ;A9EDFB;
@@ -12769,6 +12798,7 @@ UNUSED_Spritemap_Corpse_A9EE2B:
     dw $2F0C,$01F4                                                       ;A9EE35;
     db $FA                                                               ;A9EE39;
     dw $2F0B                                                             ;A9EE3A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemap_CorpseSidehopper_Alive_0:
     dw $0007,$0000                                                       ;A9EE3C;
@@ -12829,6 +12859,7 @@ Spritemap_CorpseSidehopper_Alive_2:
     db $EB                                                               ;A9EEBC;
     dw $2180                                                             ;A9EEBD;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_GetYDividedByA_A9EEBF:
     STY.W $4204                                                          ;A9EEBF;
     SEP #$20                                                             ;A9EEC2;
@@ -12840,6 +12871,7 @@ UNUSED_GetYDividedByA_A9EEBF:
     NOP                                                                  ;A9EECC;
     LDA.W $4214                                                          ;A9EECD;
     RTS                                                                  ;A9EED0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 CheckForEnemyCollisionWithEnemy:

--- a/src/bank_AA.asm
+++ b/src/bank_AA.asm
@@ -169,6 +169,7 @@ Instruction_CommonAA_CallFunctionInY_WithA:
     RTL                                                                  ;AA80B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonAA_CallExternalFunctionInY_AA80B5:
     LDA.W $0000,Y                                                        ;AA80B5;
     STA.B $12                                                            ;AA80B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonAA_CallExternalFunctionInY_WithA_AA80CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;AA80EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonAA_GotoY:
@@ -472,10 +474,12 @@ ExtendedSpritemap_Torizo_Blank:
     dw Spritemap_Torizo_Blank                                            ;AA87D6;
     dw Hitboxes_Torizo_Blank                                             ;AA87D8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_AA87DA:
     dw $0001,$FFF5,$FFD6,$000A,$0003                                     ;AA87DA;
     dw EnemyTouch_Torizo                                                 ;AA87E4;
     dw EnemyShot_Torizo_Normal                                           ;AA87E6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_0:
     dw $0001,$FFF0,$FFE5,$0010,$001B                                     ;AA87E8;
@@ -523,50 +527,62 @@ Hitboxes_Torizo_StandUp_SitDown_FacingLeft_8:
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_9:
     dw $0000                                                             ;AA885A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA885C:
     dw $0001,$FFF0,$0027,$FFFF,$0037                                     ;AA885C;
     dw EnemyTouch_Torizo                                                 ;AA8866;
     dw RTL_AAC9C1                                                        ;AA8868;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_A:
     dw $0000                                                             ;AA886A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA886C:
     dw $0001,$FFE0,$0029,$FFF3,$0040                                     ;AA886C;
     dw EnemyTouch_Torizo                                                 ;AA8876;
     dw RTL_AAC9C1                                                        ;AA8878;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_B:
     dw $0000                                                             ;AA887A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA887C:
     dw $0001,$FFD8,$001C,$FFEC,$0030                                     ;AA887C;
     dw EnemyTouch_Torizo                                                 ;AA8886;
     dw RTL_AAC9C1                                                        ;AA8888;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_C:
     dw $0000                                                             ;AA888A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA888C:
     dw $0001,$FFC8,$0009,$FFEB,$0014                                     ;AA888C;
     dw EnemyTouch_Torizo                                                 ;AA8896;
     dw RTL_AAC9C1                                                        ;AA8898;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_D:
     dw $0000                                                             ;AA889A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA889C:
     dw $0001,$FFD3,$FFF3,$FFE5,$0003                                     ;AA889C;
     dw EnemyTouch_Torizo                                                 ;AA88A6;
     dw RTL_AAC9C1                                                        ;AA88A8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_E:
     dw $0000                                                             ;AA88AA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA88AC:
     dw $0001,$FFE3,$FFDB,$FFF0,$FFF1                                     ;AA88AC;
     dw EnemyTouch_Torizo                                                 ;AA88B6;
     dw RTL_AAC9C1                                                        ;AA88B8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_F:
     dw $0000                                                             ;AA88BA;
@@ -574,50 +590,62 @@ Hitboxes_Torizo_StandUp_SitDown_FacingLeft_F:
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_10:
     dw $0000                                                             ;AA88BC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA88BE:
     dw $0001,$FFEF,$0028,$0000,$0039                                     ;AA88BE;
     dw EnemyTouch_Torizo                                                 ;AA88C8;
     dw RTL_AAC9C1                                                        ;AA88CA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_11:
     dw $0000                                                             ;AA88CC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA88CE:
     dw $0001,$FFE6,$0021,$FFF4,$0032                                     ;AA88CE;
     dw EnemyTouch_Torizo                                                 ;AA88D8;
     dw RTL_AAC9C1                                                        ;AA88DA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_12:
     dw $0000                                                             ;AA88DC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA88DE:
     dw $0001,$FFDD,$0018,$FFEA,$0025                                     ;AA88DE;
     dw EnemyTouch_Torizo                                                 ;AA88E8;
     dw RTL_AAC9C1                                                        ;AA88EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_13:
     dw $0000                                                             ;AA88EC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA88EE:
     dw $0001,$FFCA,$0008,$FFE9,$0012                                     ;AA88EE;
     dw EnemyTouch_Torizo                                                 ;AA88F8;
     dw RTL_AAC9C1                                                        ;AA88FA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_14:
     dw $0000                                                             ;AA88FC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA88FE:
     dw $0001,$FFD3,$FFF3,$FFE3,$0000                                     ;AA88FE;
     dw EnemyTouch_Torizo                                                 ;AA8908;
     dw RTL_AAC9C1                                                        ;AA890A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_15:
     dw $0000                                                             ;AA890C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA890E:
     dw $0001,$FFE4,$FFDA,$FFEF,$FFEE                                     ;AA890E;
     dw EnemyTouch_Torizo                                                 ;AA8918;
     dw RTL_AAC9C1                                                        ;AA891A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingLeft_16:
     dw $0001,$FFEE,$FFDA,$0007,$0009                                     ;AA891C;
@@ -629,10 +657,12 @@ Hitboxes_Torizo_StandUp_SitDown_FacingLeft_17:
     dw EnemyTouch_Torizo                                                 ;AA8934;
     dw EnemyShot_Torizo_Normal                                           ;AA8936;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_Torizo_StandUp_SitDown_FacingLeft_AA8938:
     dw $0001,$FFF5,$FFD6,$000A,$0007                                     ;AA8938;
     dw EnemyTouch_Torizo                                                 ;AA8942;
     dw EnemyShot_Torizo_Normal                                           ;AA8944;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_Torizo_StandUp_SitDown_FacingRight_0:
     dw $0001,$FFF1,$FFE5,$000D,$001B                                     ;AA8946;
@@ -972,6 +1002,7 @@ Spritemaps_Torizo_B:
     db $FC                                                               ;AA8C22;
     dw $6B6A                                                             ;AA8C23;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Torizo_AA8C25:
     dw $0001,$81F8                                                       ;AA8C25;
     db $F8                                                               ;AA8C29;
@@ -981,6 +1012,7 @@ UNUSED_Spritemaps_Torizo_AA8C2C:
     dw $0001,$81F8                                                       ;AA8C2C;
     db $F8                                                               ;AA8C30;
     dw $2304                                                             ;AA8C31;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_Torizo_C:
     dw $001A,$01E9                                                       ;AA8C33;
@@ -2208,6 +2240,7 @@ Spritemaps_Torizo_2F:
     db $D9                                                               ;AA9763;
     dw $2300                                                             ;AA9764;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Torizo_AA9766:
     dw $0006,$8000                                                       ;AA9766;
     db $0C                                                               ;AA976A;
@@ -2222,6 +2255,7 @@ UNUSED_Spritemaps_Torizo_AA9766:
     dw $2302,$81F0                                                       ;AA977F;
     db $EC                                                               ;AA9783;
     dw $2300                                                             ;AA9784;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_Torizo_30:
     dw $0004,$01EC                                                       ;AA9786;
@@ -2291,6 +2325,7 @@ Spritemaps_Torizo_35:
     db $F4                                                               ;AA980C;
     dw $63C4                                                             ;AA980D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Torizo_AA980F:
     dw $0013,$01F5                                                       ;AA980F;
     db $10                                                               ;AA9813;
@@ -2438,6 +2473,7 @@ UNUSED_Spritemaps_Torizo_AA992A:
     dw $6B92,$0000                                                       ;AA9943;
     db $F0                                                               ;AA9947;
     dw $6B82                                                             ;AA9948;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_Torizo_36:
     dw $001A,$000F                                                       ;AA994A;
@@ -2494,10 +2530,12 @@ Spritemaps_Torizo_36:
     db $E6                                                               ;AA99CB;
     dw $6302                                                             ;AA99CC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Torizo_UnusedEntry_AA99CE:
     dw $81F8                                                             ;AA99CE;
     db $E6                                                               ;AA99D0;
     dw $6300                                                             ;AA99D1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_Torizo_37:
     dw $001A,$81F3                                                       ;AA99D3;
@@ -2831,6 +2869,7 @@ Spritemaps_Torizo_3C:
     db $D9                                                               ;AA9CED;
     dw $6300                                                             ;AA9CEE;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Torizo_AA9CF0:
     dw $0002,$01F8                                                       ;AA9CF0;
     db $FC                                                               ;AA9CF4;
@@ -2866,6 +2905,7 @@ UNUSED_Spritemaps_Torizo_AA9D23:
     dw $2B80,$81F8                                                       ;AA9D2D;
     db $F2                                                               ;AA9D31;
     dw $2B2E                                                             ;AA9D32;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spritemaps_Torizo_3D:
     dw $0016,$000D                                                       ;AA9D34;
@@ -3706,6 +3746,7 @@ Spritemaps_Torizo_59:
     db $D9                                                               ;AAA4C3;
     dw $6300                                                             ;AAA4C4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Torizo_AAA4C6:
     dw $0006,$81F0                                                       ;AAA4C6;
     db $0C                                                               ;AAA4CA;
@@ -3725,6 +3766,7 @@ UNUSED_ExtendedSpritemaps_Torizo_AAA4E6:
     dw $0001,$0000,$0000                                                 ;AAA4E6;
     dw Spritemaps_Torizo_7                                               ;AAA4EC;
     dw UNUSED_Hitboxes_Torizo_AA87DA                                     ;AAA4EE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_Torizo_FacingScreen_Turning_Dodging:
     dw $0001,$0000,$0000                                                 ;AAA4F0;
@@ -4265,6 +4307,7 @@ ExtSpritemap_Torizo_SonicBoom_Swipe_FaceLeft_LeftFootFwd_3:
     dw Spritemaps_Torizo_2A                                              ;AAA9FA;
     dw Hitboxes_Torizo_StandUp_SitDown_FacingLeft_15                     ;AAA9FC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_Torizo_AAA9FE:
     dw $0001,$0000,$0008                                                 ;AAA9FE;
     dw Spritemaps_Torizo_6                                               ;AAAA04;
@@ -4274,6 +4317,7 @@ UNUSED_ExtendedSpritemaps_Torizo_AAAA08:
     dw $0001,$0000,$0008                                                 ;AAAA08;
     dw Spritemaps_Torizo_7                                               ;AAAA0E;
     dw UNUSED_Hitboxes_Torizo_AA87DA                                     ;AAAA10;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_Torizo_StandUp_SitDown_FacingLeft_0:
     dw $0001,$0000,$0000                                                 ;AAAA12;
@@ -4319,6 +4363,7 @@ ExtendedSpritemaps_Torizo_StandUp_SitDown_FacingLeft_6:
     dw Spritemaps_Torizo_12                                              ;AAAA6C;
     dw Hitboxes_Torizo_StandUp_SitDown_FacingLeft_6                      ;AAAA6E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_Torizo_AAAA70:
     dw $0001,$0000,$0000                                                 ;AAAA70;
     dw Spritemaps_Torizo_8                                               ;AAAA76;
@@ -4338,6 +4383,7 @@ UNUSED_ExtendedSpritemaps_Torizo_AAAA8E:
     dw $0001,$0000,$0000                                                 ;AAAA8E;
     dw Spritemaps_Torizo_B                                               ;AAAA94;
     dw Hitboxes_Torizo_Blank                                             ;AAAA96;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_Torizo_WalkingRight_LeftLegMoving_0:
     dw $0004,$000F,$FFE2                                                 ;AAAA98;
@@ -6022,6 +6068,7 @@ InstList_Torizo_FacingLeft_Faceless_Walking_LeftLegMoving:
     dw Instruction_Common_GotoY                                          ;AABD8C;
     dw InstList_Torizo_FacingLeft_Faceless_Walking_RightLegMoving        ;AABD8E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Torizo_FacingRight_StandUp_AABD90:
     dw Instruction_Torizo_SetSteppedRightWithLeftFootState               ;AABD90;
     dw $0001                                                             ;AABD92;
@@ -6053,6 +6100,7 @@ UNUSED_InstList_Torizo_FacingRight_StandUp_AABD90:
     dw ExtendedSpritemaps_Torizo_StandUp_SitDown_FacingRight_6           ;AABDD2;
     dw Instruction_Common_GotoY                                          ;AABDD4;
     dw InstList_Torizo_FacingRight_Walking_RightLegMoving                ;AABDD6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Torizo_FacingRight_TurningRight:
     dw Instruction_Torizo_FunctionInY                                    ;AABDD8;
@@ -7304,6 +7352,7 @@ RTS_AAC6AB:
     RTS                                                                  ;AAC6AB;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Torizo_AAC6AC:
     JSR.W HandleFalling                                                  ;AAC6AC;
     LDA.W #$0600                                                         ;AAC6AF;
@@ -7314,6 +7363,7 @@ UNUSED_Torizo_AAC6AC:
 
 .return:
     RTS                                                                  ;AAC6BE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_Torizo_SimpleMovement:
@@ -10595,8 +10645,10 @@ ShaktoolPieceData_initialCurlingNeighborAngleDelta_leftSaw:
 ShaktoolPieceData_zero:
     dw $0000,$0000,$0000,$0000,$0000,$0000,$0000                         ;AADEF7;
 
+if !FEATURE_KEEP_UNREFERENCED
 ShaktoolPieceData_unused:
     dw $0000,$0000,$0002,$0004,$0006,$0008,$000A                         ;AADF05;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ShaktoolPieceData_headBobInstListPointer:
     dw InstList_Shaktool_SawHand_HeadBob_PrimaryPiece                    ;AADF13;

--- a/src/bank_AF.asm
+++ b/src/bank_AF.asm
@@ -5,8 +5,10 @@ org $AF8000
 Tiles_Oum:
 incbin "../data/Tiles_Oum.bin" ; $800 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Tiles_Gravy_AF8800:
 incbin "../data/UNUSED_Tiles_Gravy_AF8800.bin" ; $A00 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Tiles_Metaree:
 incbin "../data/Tiles_Metaree.bin" ; $600 bytes

--- a/src/bank_B0.asm
+++ b/src/bank_B0.asm
@@ -5,8 +5,10 @@ org $B08000
 Tiles_Debug_PaletteViewer:
 incbin "../data/Tiles_Debug_PaletteViewer.bin" ; $1000 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Tiles_SolidColor_B09000:
 incbin "../data/UNUSED_Tiles_SolidColor_B09000.bin" ; $400 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Tiles_Ridley_0:
 incbin "../data/Tiles_Ridley_0.bin" ; $440 bytes

--- a/src/bank_B2.asm
+++ b/src/bank_B2.asm
@@ -169,6 +169,7 @@ Instruction_CommonB2_CallFunctionInY_WithA:
     RTL                                                                  ;B280B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonB2_CallExternalFunctionInY_B280B5:
     LDA.W $0000,Y                                                        ;B280B5;
     STA.B $12                                                            ;B280B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonB2_CallExternalFunctionInY_WithA_B280CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;B280EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonB2_GotoY:
@@ -443,9 +445,11 @@ Palette_Pirate_Gold_NonNinja:
     dw $3800,$4BBE,$06B9,$00EA,$0065,$173A,$0276,$01F2                   ;B28727;
     dw $014D,$5EBB,$3DB3,$292E,$1486,$033B,$0216,$0113                   ;B28737;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Palette_Pirate_Silver_GoldNinja_B28747:
     dw $3800,$6BFF,$4ED6,$14A4,$0420,$5B7B,$3E52,$31CD                   ;B28747;
     dw $2149,$5EBB,$3DB3,$292E,$1486,$033B,$0216,$0113                   ;B28757;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 PowerBombReaction_Ninja_Walking_GreyWall:
     JSL.L NormalEnemyPowerBombAI                                         ;B28767;
@@ -1450,6 +1454,7 @@ ExtendedSpritemaps_PirateNinja_39:
     dw Spitemaps_PirateWalking_2F                                        ;B28FB6;
     dw Hitboxes_PirateNinja_3F                                           ;B28FB8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_SpacePirate_B28FBA:
     dw $0001,$0000,$0000                                                 ;B28FBA;
     dw UNUSED_Spitemaps_SpacePirate_B2DEBA                               ;B28FC0;
@@ -1489,6 +1494,7 @@ UNUSED_ExtendedSpritemaps_SpacePirate_B29000:
     dw $0001,$0000,$0000                                                 ;B29000;
     dw UNUSED_Spitemaps_SpacePirate_B2E815                               ;B29006;
     dw UNUSED_Hitboxes_SpacePirate_B2A78A                                ;B29008;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_PirateNinja_3A:
     dw $0001,$0000,$0000                                                 ;B2900A;
@@ -1530,6 +1536,7 @@ ExtendedSpritemaps_PirateNinja_41:
     dw Spitemaps_PirateNinja_51                                          ;B29056;
     dw Hitboxes_PirateNinja_63                                           ;B29058;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_SpacePirate_B2905A:
     dw $0001,$0000,$0000                                                 ;B2905A;
     dw UNUSED_Spitemaps_SpacePirate_B2C9FC                               ;B29060;
@@ -1603,6 +1610,7 @@ UNUSED_ExtendedSpritemaps_SpacePirate_B290EC:
     dw $0000,$0000                                                       ;B290F6;
     dw UNUSED_Spitemaps_SpacePirate_B2D287                               ;B290FA;
     dw UNUSED_Hitboxes_SpacePirate_B2A1E0                                ;B290FC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_PirateNinja_42:
     dw $0002,$0000,$0005                                                 ;B290FE;
@@ -1612,6 +1620,7 @@ ExtendedSpritemaps_PirateNinja_42:
     dw Spitemaps_PirateNinja_3E                                          ;B2910C;
     dw Hitboxes_PirateNinja_52                                           ;B2910E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_SpacePirate_B29110:
     dw $0002,$0000,$0005                                                 ;B29110;
     dw UNUSED_Spitemaps_SpacePirate_B2DBCC                               ;B29116;
@@ -1779,6 +1788,7 @@ UNUSED_ExtendedSpritemaps_SpacePirate_B2926E:
     dw $0001,$0000                                                       ;B29278;
     dw UNUSED_Spitemaps_SpacePirate_B2D595                               ;B2927C;
     dw UNUSED_Hitboxes_SpacePirate_B2A306                                ;B2927E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_PirateNinja_43:
     dw $0002,$0000,$0005                                                 ;B29280;
@@ -1788,6 +1798,7 @@ ExtendedSpritemaps_PirateNinja_43:
     dw Spitemaps_PirateNinja_42                                          ;B2928E;
     dw Hitboxes_PirateNinja_56                                           ;B29290;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_SpacePirate_B29292:
     dw $0002,$0000,$0005                                                 ;B29292;
     dw UNUSED_Spitemaps_SpacePirate_B2E42C                               ;B29298;
@@ -1891,6 +1902,7 @@ UNUSED_ExtendedSpritemaps_SpacePirate_B29368:
     dw $0001,$0000,$0004                                                 ;B29368;
     dw UNUSED_Spitemaps_SpacePirate_B2D69E                               ;B2936E;
     dw UNUSED_Hitboxes_SpacePirate_B2A384                                ;B29370;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_PirateNinja_44:
     dw $0001,$0002,$0000                                                 ;B29372;
@@ -1902,6 +1914,7 @@ ExtendedSpritemaps_PirateNinja_45:
     dw Spitemaps_PirateNinja_4F                                          ;B29382;
     dw Hitboxes_PirateNinja_61                                           ;B29384;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_SpacePirate_B29386:
     dw $0001,$0000,$0003                                                 ;B29386;
     dw UNUSED_Spitemaps_SpacePirate_B2C9FC                               ;B2938C;
@@ -1951,6 +1964,7 @@ UNUSED_ExtendedSpritemaps_SpacePirate_B293E0:
     dw $0001,$0002,$0006                                                 ;B293E0;
     dw UNUSED_Spitemaps_SpacePirate_B2C9FC                               ;B293E6;
     dw UNUSED_Hitboxes_SpacePirate_B29FE8                                ;B293E8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 ExtendedSpritemaps_PirateNinja_46:
     dw $0003,$FFFB,$FFF4                                                 ;B293EA;
@@ -2017,6 +2031,7 @@ ExtendedSpritemaps_PirateNinja_4C:
     dw Spitemaps_PirateNinja_3C                                          ;B2947C;
     dw Hitboxes_PirateNinja_50                                           ;B2947E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_ExtendedSpritemaps_SpacePirate_B29480:
     dw $0001,$0000,$0000                                                 ;B29480;
     dw UNUSED_Spitemaps_SpacePirate_B2E9F7                               ;B29486;
@@ -2266,6 +2281,7 @@ UNUSED_ExtendedSpritemaps_SpacePirate_B29686:
     dw $0001,$0000,$0008                                                 ;B29686;
     dw UNUSED_Spitemaps_SpacePirate_B2E88C                               ;B2968C;
     dw UNUSED_Hitboxes_SpacePirate_B2A7A6                                ;B2968E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateWall_0:
     dw $0001,$FFEE,$FFED,$0006,$0000                                     ;B29690;
@@ -2767,6 +2783,7 @@ Hitboxes_PirateNinja_27:
     dw EnemyTouch_SpacePirate                                            ;B29C04;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29C06;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29C08:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B29C08;
     dw EnemyTouch_SpacePirate                                            ;B29C12;
@@ -2796,16 +2813,19 @@ UNUSED_Hitboxes_SpacePirate_B29C4E:
     dw $0001,$FFF0,$FFED,$000B,$0010                                     ;B29C4E;
     dw EnemyTouch_SpacePirate                                            ;B29C58;
     dw EnemyShot_SpacePirate_Normal                                      ;B29C5A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_28:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B29C5C;
     dw EnemyTouch_SpacePirate                                            ;B29C66;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29C68;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29C6A:
     dw $0001,$FFF9,$FFF7,$0006,$0006                                     ;B29C6A;
     dw EnemyTouch_SpacePirate                                            ;B29C74;
     dw EnemyShot_SpacePirate_Normal                                      ;B29C76;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateWalking_38:
     dw $0002,$FFF9,$FFED,$0006,$0017                                     ;B29C78;
@@ -2823,6 +2843,7 @@ Hitboxes_PirateNinja_29:
     dw EnemyTouch_SpacePirate                                            ;B29CA8;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29CAA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29CAC:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B29CAC;
     dw EnemyTouch_SpacePirate                                            ;B29CB6;
@@ -2843,6 +2864,7 @@ UNUSED_Hitboxes_SpacePirate_B29CD4:
     dw $FFE0,$FFFA,$FFFE,$0004                                           ;B29CE2;
     dw EnemyTouch_SpacePirate                                            ;B29CEA;
     dw EnemyShot_SpacePirate_Normal                                      ;B29CEC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_2A:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B29CEE;
@@ -2944,6 +2966,7 @@ Hitboxes_PirateNinja_3D:
     dw EnemyTouch_SpacePirate                                            ;B29E02;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29E04;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29E06:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B29E06;
     dw EnemyTouch_SpacePirate                                            ;B29E10;
@@ -2973,6 +2996,7 @@ UNUSED_Hitboxes_SpacePirate_B29E4C:
     dw $0001,$FFF5,$FFED,$000E,$0010                                     ;B29E4C;
     dw EnemyTouch_SpacePirate                                            ;B29E56;
     dw EnemyShot_SpacePirate_Normal                                      ;B29E58;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_3E:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B29E5A;
@@ -2995,6 +3019,7 @@ Hitboxes_PirateNinja_3F:
     dw EnemyTouch_SpacePirate                                            ;B29E98;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29E9A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29E9C:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B29E9C;
     dw EnemyTouch_SpacePirate                                            ;B29EA6;
@@ -3015,6 +3040,7 @@ UNUSED_Hitboxes_SpacePirate_B29EC4:
     dw $0006,$FFFA,$001F,$0004                                           ;B29ED2;
     dw EnemyTouch_SpacePirate                                            ;B29EDA;
     dw EnemyShot_SpacePirate_Normal                                      ;B29EDC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_40:
     dw $0001,$FFF5,$FFF3,$000A,$000A                                     ;B29EDE;
@@ -3056,6 +3082,7 @@ Hitboxes_PirateNinja_47:
     dw EnemyTouch_SpacePirate                                            ;B29F4A;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29F4C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29F4E:
     dw $0001,$FFF3,$FFEC,$000C,$0006                                     ;B29F4E;
     dw EnemyTouch_SpacePirate                                            ;B29F58;
@@ -3070,6 +3097,7 @@ UNUSED_Hitboxes_SpacePirate_B29F6A:
     dw $0001,$FFF8,$FFEA,$000C,$0019                                     ;B29F6A;
     dw EnemyTouch_SpacePirate                                            ;B29F74;
     dw EnemyShot_SpacePirate_Normal                                      ;B29F76;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_48:
     dw $0001,$FFF5,$FFF3,$000A,$000A                                     ;B29F78;
@@ -3111,6 +3139,7 @@ Hitboxes_PirateNinja_4F:
     dw EnemyTouch_SpacePirate                                            ;B29FE4;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B29FE6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B29FE8:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B29FE8;
     dw EnemyTouch_SpacePirate                                            ;B29FF2;
@@ -3160,12 +3189,14 @@ UNUSED_Hitboxes_SpacePirate_B2A066:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A066;
     dw EnemyTouch_SpacePirate                                            ;B2A070;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A072;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_50:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B2A074;
     dw EnemyTouch_SpacePirate                                            ;B2A07E;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A080;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A082:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A082;
     dw EnemyTouch_SpacePirate                                            ;B2A08C;
@@ -3295,12 +3326,14 @@ UNUSED_Hitboxes_SpacePirate_B2A1E0:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A1E0;
     dw EnemyTouch_SpacePirate                                            ;B2A1EA;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A1EC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_51:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A1EE;
     dw EnemyTouch_SpacePirate                                            ;B2A1F8;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A1FA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A1FC:
     dw $0001,$FFF9,$0000,$0006,$0010                                     ;B2A1FC;
     dw EnemyTouch_SpacePirate                                            ;B2A206;
@@ -3345,6 +3378,7 @@ UNUSED_Hitboxes_SpacePirate_B2A26C:
     dw $0001,$FFF9,$FFF7,$0006,$0006                                     ;B2A26C;
     dw EnemyTouch_SpacePirate                                            ;B2A276;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A278;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_52:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A27A;
@@ -3361,6 +3395,7 @@ Hitboxes_PirateNinja_54:
     dw EnemyTouch_SpacePirate                                            ;B2A2A0;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A2A2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A2A4:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A2A4;
     dw EnemyTouch_SpacePirate                                            ;B2A2AE;
@@ -3400,12 +3435,14 @@ UNUSED_Hitboxes_SpacePirate_B2A306:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A306;
     dw EnemyTouch_SpacePirate                                            ;B2A310;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A312;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_55:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A314;
     dw EnemyTouch_SpacePirate                                            ;B2A31E;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A320;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A322:
     dw $0001,$FFF9,$FFF7,$0006,$0006                                     ;B2A322;
     dw EnemyTouch_SpacePirate                                            ;B2A32C;
@@ -3445,6 +3482,7 @@ UNUSED_Hitboxes_SpacePirate_B2A384:
     dw $0001,$FFF9,$FFF7,$0006,$0006                                     ;B2A384;
     dw EnemyTouch_SpacePirate                                            ;B2A38E;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A390;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_56:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A392;
@@ -3456,6 +3494,7 @@ Hitboxes_PirateNinja_57:
     dw EnemyTouch_SpacePirate                                            ;B2A3AA;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A3AC;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A3AE:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A3AE;
     dw EnemyTouch_SpacePirate                                            ;B2A3B8;
@@ -3480,12 +3519,14 @@ UNUSED_Hitboxes_SpacePirate_B2A3E6:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A3E6;
     dw EnemyTouch_SpacePirate                                            ;B2A3F0;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A3F2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_58:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A3F4;
     dw EnemyTouch_SpacePirate                                            ;B2A3FE;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A400;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A402:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A402;
     dw EnemyTouch_SpacePirate                                            ;B2A40C;
@@ -3550,12 +3591,14 @@ UNUSED_Hitboxes_SpacePirate_B2A4AA:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A4AA;
     dw EnemyTouch_SpacePirate                                            ;B2A4B4;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A4B6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_59:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A4B8;
     dw EnemyTouch_SpacePirate                                            ;B2A4C2;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A4C4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A4C6:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A4C6;
     dw EnemyTouch_SpacePirate                                            ;B2A4D0;
@@ -3610,6 +3653,7 @@ UNUSED_Hitboxes_SpacePirate_B2A552:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B2A552;
     dw EnemyTouch_SpacePirate                                            ;B2A55C;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A55E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_5A:
     dw $0001,$FFF9,$FFED,$0006,$0010                                     ;B2A560;
@@ -3621,6 +3665,7 @@ Hitboxes_PirateNinja_5B:
     dw EnemyTouch_SpacePirate                                            ;B2A578;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A57A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A57C:
     dw $0001,$FFF9,$FFED,$0006,$0010                                     ;B2A57C;
     dw EnemyTouch_SpacePirate                                            ;B2A586;
@@ -3658,6 +3703,7 @@ UNUSED_Hitboxes_SpacePirate_B2A5D0:
     dw $FFEE,$FFEE,$FFF9,$0002                                           ;B2A5DE;
     dw EnemyTouch_SpacePirate                                            ;B2A5E6;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A5E8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_5C:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B2A5EA;
@@ -3680,6 +3726,7 @@ Hitboxes_PirateNinja_5E:
     dw EnemyTouch_SpacePirate                                            ;B2A628;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A62A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A62C:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A62C;
     dw EnemyTouch_SpacePirate                                            ;B2A636;
@@ -3719,12 +3766,14 @@ UNUSED_Hitboxes_SpacePirate_B2A68E:
     dw $0001,$FFF9,$0000,$0006,$001E                                     ;B2A68E;
     dw EnemyTouch_SpacePirate                                            ;B2A698;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A69A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_5F:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A69C;
     dw EnemyTouch_SpacePirate                                            ;B2A6A6;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A6A8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A6AA:
     dw $0001,$FFF9,$FFED,$0006,$0000                                     ;B2A6AA;
     dw EnemyTouch_SpacePirate                                            ;B2A6B4;
@@ -3779,6 +3828,7 @@ UNUSED_Hitboxes_SpacePirate_B2A736:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B2A736;
     dw EnemyTouch_SpacePirate                                            ;B2A740;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A742;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_60:
     dw $0001,$FFF9,$FFED,$0006,$0010                                     ;B2A744;
@@ -3790,6 +3840,7 @@ Hitboxes_PirateNinja_61:
     dw EnemyTouch_SpacePirate                                            ;B2A75C;
     dw EnemyShot_SpacePirate_GoldNinjaIsInvincible                       ;B2A75E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A760:
     dw $0001,$FFF9,$FFED,$0006,$0010                                     ;B2A760;
     dw EnemyTouch_SpacePirate                                            ;B2A76A;
@@ -3822,6 +3873,7 @@ UNUSED_Hitboxes_SpacePirate_B2A7A6:
     dw $0006,$FFED,$0011,$0001                                           ;B2A7B4;
     dw EnemyTouch_SpacePirate                                            ;B2A7BC;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A7BE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Hitboxes_PirateNinja_62:
     dw $0001,$FFF9,$FFED,$0006,$001E                                     ;B2A7C0;
@@ -3844,6 +3896,7 @@ Hitboxes_PirateNinja_64:
     dw EnemyTouch_SpacePirate                                            ;B2A7FE;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A800;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Hitboxes_SpacePirate_B2A802:
     dw $0001,$FFF5,$FFF3,$000A,$000A                                     ;B2A802;
     dw EnemyTouch_SpacePirate                                            ;B2A80C;
@@ -3923,6 +3976,7 @@ UNUSED_Hitboxes_SpacePirate_B2A8D4:
     dw $0001,$FFF5,$FFF3,$000A,$000A                                     ;B2A8D4;
     dw EnemyTouch_SpacePirate                                            ;B2A8DE;
     dw EnemyShot_SpacePirate_Normal                                      ;B2A8E0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateWall_0:
     dw $0008,$01EF                                                       ;B2A8E2;
@@ -5221,6 +5275,7 @@ Spitemaps_PirateWalking_16_Ninja_3:
     db $09                                                               ;B2B471;
     dw $6124                                                             ;B2B472;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2B474:
     dw $000A,$81F9                                                       ;B2B474;
     db $FF                                                               ;B2B478;
@@ -5243,6 +5298,7 @@ UNUSED_Spitemaps_SpacePirate_B2B474:
     dw $6144,$01FA                                                       ;B2B4A1;
     db $0B                                                               ;B2B4A5;
     dw $6143                                                             ;B2B4A6;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateWalking_17_Ninja_4:
     dw $000A,$01FC                                                       ;B2B4A8;
@@ -6034,6 +6090,7 @@ Spitemaps_PirateNinja_17:
     db $FE                                                               ;B2BBA1;
     dw $214A                                                             ;B2BBA2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2BBA4:
     dw $000E,$81F4                                                       ;B2BBA4;
     db $FF                                                               ;B2BBA8;
@@ -6241,6 +6298,7 @@ UNUSED_Spitemaps_SpacePirate_B2BD43:
     dw $213D,$01EE                                                       ;B2BD84;
     db $E7                                                               ;B2BD88;
     dw $212D                                                             ;B2BD89;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_18:
     dw $0009,$01F9                                                       ;B2BD8B;
@@ -6263,6 +6321,7 @@ Spitemaps_PirateNinja_18:
     db $FE                                                               ;B2BDB7;
     dw $214A                                                             ;B2BDB8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2BDBA:
     dw $0003,$01FC                                                       ;B2BDBA;
     db $04                                                               ;B2BDBE;
@@ -6271,6 +6330,7 @@ UNUSED_Spitemaps_SpacePirate_B2BDBA:
     dw $213D,$01FC                                                       ;B2BDC4;
     db $F4                                                               ;B2BDC8;
     dw $212D                                                             ;B2BDC9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateWalking_2A_Ninja_18:
     dw $0010,$81F9                                                       ;B2BDCB;
@@ -6307,6 +6367,7 @@ Spitemaps_PirateWalking_2A_Ninja_18:
     db $10                                                               ;B2BE1A;
     dw $2125                                                             ;B2BE1B;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2BE1D:
     dw $0011,$81F3                                                       ;B2BE1D;
     db $FB                                                               ;B2BE21;
@@ -6431,6 +6492,7 @@ UNUSED_Spitemaps_SpacePirate_B2BED5:
     dw $E18D,$01DE                                                       ;B2BF3E;
     db $FD                                                               ;B2BF42;
     dw $E17D                                                             ;B2BF43;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_19:
     dw $000A,$81FC                                                       ;B2BF45;
@@ -6921,6 +6983,7 @@ Spitemaps_PirateNinja_2B:
     db $FE                                                               ;B2C3A0;
     dw $614A                                                             ;B2C3A1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2C3A3:
     dw $000E,$81FC                                                       ;B2C3A3;
     db $FF                                                               ;B2C3A7;
@@ -7128,6 +7191,7 @@ UNUSED_Spitemaps_SpacePirate_B2C542:
     dw $613D,$000A                                                       ;B2C583;
     db $E7                                                               ;B2C587;
     dw $612D                                                             ;B2C588;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_2C:
     dw $0009,$01FF                                                       ;B2C58A;
@@ -7185,6 +7249,7 @@ Spitemaps_PirateWalking_2F:
     db $10                                                               ;B2C608;
     dw $6125                                                             ;B2C609;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2C60B:
     dw $0011,$81FD                                                       ;B2C60B;
     db $FB                                                               ;B2C60F;
@@ -7309,6 +7374,7 @@ UNUSED_Spitemaps_SpacePirate_B2C6C3:
     dw $A18D,$001A                                                       ;B2C72C;
     db $FD                                                               ;B2C730;
     dw $A17D                                                             ;B2C731;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_2D:
     dw $0004,$81FA                                                       ;B2C733;
@@ -7422,6 +7488,7 @@ Spitemaps_PirateNinja_33:
     db $EE                                                               ;B2C81C;
     dw $21A2                                                             ;B2C81D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2C81F:
     dw $000D,$81F9                                                       ;B2C81F;
     db $FC                                                               ;B2C823;
@@ -7524,6 +7591,7 @@ UNUSED_Spitemaps_SpacePirate_B2C8AA:
     dw $6144,$01FA                                                       ;B2C909;
     db $0B                                                               ;B2C90D;
     dw $6143                                                             ;B2C90E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_34:
     dw $0004,$81F6                                                       ;B2C910;
@@ -7637,6 +7705,7 @@ Spitemaps_PirateNinja_3B:
     db $EE                                                               ;B2C9F9;
     dw $61A2                                                             ;B2C9FA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2C9FC:
     dw $0008,$01EF                                                       ;B2C9FC;
     db $FD                                                               ;B2CA00;
@@ -7866,6 +7935,7 @@ UNUSED_Spitemaps_SpacePirate_B2CBD0:
     dw $2107,$01EC                                                       ;B2CBFD;
     db $16                                                               ;B2CC01;
     dw $2145                                                             ;B2CC02;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_3C:
     dw $0014,$0007                                                       ;B2CC04;
@@ -7910,6 +7980,7 @@ Spitemaps_PirateNinja_3C:
     db $E8                                                               ;B2CC67;
     dw $2154                                                             ;B2CC68;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2CC6A:
     dw $000D,$81F9                                                       ;B2CC6A;
     db $FC                                                               ;B2CC6E;
@@ -8615,6 +8686,7 @@ UNUSED_Spitemaps_SpacePirate_B2D287:
     dw $211B,$01FD                                                       ;B2D2B9;
     db $FF                                                               ;B2D2BD;
     dw $210B                                                             ;B2D2BE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_3D:
     dw $000A,$01F8                                                       ;B2D2C0;
@@ -8639,6 +8711,7 @@ Spitemaps_PirateNinja_3D:
     db $09                                                               ;B2D2F1;
     dw $2124                                                             ;B2D2F2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2D2F4:
     dw $000A,$81F7                                                       ;B2D2F4;
     db $FF                                                               ;B2D2F8;
@@ -8725,6 +8798,7 @@ UNUSED_Spitemaps_SpacePirate_B2D390:
     dw $212B,$81F4                                                       ;B2D395;
     db $F8                                                               ;B2D399;
     dw $212A                                                             ;B2D39A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_3E:
     dw $000A,$01FC                                                       ;B2D39C;
@@ -8775,6 +8849,7 @@ Spitemaps_PirateNinja_40:
     db $F0                                                               ;B2D403;
     dw $612E                                                             ;B2D404;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2D406:
     dw $000A,$0003                                                       ;B2D406;
     db $13                                                               ;B2D40A;
@@ -8974,6 +9049,7 @@ UNUSED_Spitemaps_SpacePirate_B2D595:
     dw $611B,$01FB                                                       ;B2D5C7;
     db $FF                                                               ;B2D5CB;
     dw $610B                                                             ;B2D5CC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_41:
     dw $000A,$0000                                                       ;B2D5CE;
@@ -8998,6 +9074,7 @@ Spitemaps_PirateNinja_41:
     db $09                                                               ;B2D5FF;
     dw $6124                                                             ;B2D600;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2D602:
     dw $000A,$81F9                                                       ;B2D602;
     db $FF                                                               ;B2D606;
@@ -9084,6 +9161,7 @@ UNUSED_Spitemaps_SpacePirate_B2D69E:
     dw $612B,$81FC                                                       ;B2D6A3;
     db $F8                                                               ;B2D6A7;
     dw $612A                                                             ;B2D6A8;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_42:
     dw $000A,$01FC                                                       ;B2D6AA;
@@ -9151,6 +9229,7 @@ Spitemaps_PirateNinja_45:
     db $EB                                                               ;B2D736;
     dw $210E                                                             ;B2D737;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2D739:
     dw $0009,$01FA                                                       ;B2D739;
     db $FB                                                               ;B2D73D;
@@ -9257,6 +9336,7 @@ UNUSED_Spitemaps_SpacePirate_B2D7FA:
     dw $212E,$81EA                                                       ;B2D822;
     db $F0                                                               ;B2D826;
     dw $210E                                                             ;B2D827;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_46:
     dw $0009,$01FD                                                       ;B2D829;
@@ -9279,6 +9359,7 @@ Spitemaps_PirateNinja_46:
     db $EB                                                               ;B2D855;
     dw $610E                                                             ;B2D856;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2D858:
     dw $0009,$01FE                                                       ;B2D858;
     db $FB                                                               ;B2D85C;
@@ -9589,6 +9670,7 @@ UNUSED_Spitemaps_SpacePirate_B2DAE1:
     dw $211B,$01FD                                                       ;B2DB13;
     db $FF                                                               ;B2DB17;
     dw $210B                                                             ;B2DB18;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_47:
     dw $0009,$01FC                                                       ;B2DB1A;
@@ -9611,6 +9693,7 @@ Spitemaps_PirateNinja_47:
     db $FE                                                               ;B2DB46;
     dw $214A                                                             ;B2DB47;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2DB49:
     dw $0009,$81EB                                                       ;B2DB49;
     db $00                                                               ;B2DB4D;
@@ -9905,6 +9988,7 @@ UNUSED_Spitemaps_SpacePirate_B2DDA6:
     dw $2126,$01F3                                                       ;B2DDE7;
     db $15                                                               ;B2DDEB;
     dw $2125                                                             ;B2DDEC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_48:
     dw $0012,$81F3                                                       ;B2DDEE;
@@ -9992,6 +10076,7 @@ Spitemaps_PirateNinja_49:
     db $09                                                               ;B2DEB7;
     dw $E12D                                                             ;B2DEB8;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2DEBA:
     dw $0014,$01F8                                                       ;B2DEBA;
     db $F2                                                               ;B2DEBE;
@@ -10194,6 +10279,7 @@ UNUSED_Spitemaps_SpacePirate_B2E03D:
     dw $2126,$01F2                                                       ;B2E088;
     db $10                                                               ;B2E08C;
     dw $2125                                                             ;B2E08D;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_4A:
     dw $0011,$81F3                                                       ;B2E08F;
@@ -10314,6 +10400,7 @@ Spitemaps_PirateNinja_4C:
     db $DA                                                               ;B2E1A5;
     dw $212D                                                             ;B2E1A6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2E1A8:
     dw $000A,$81FC                                                       ;B2E1A8;
     db $00                                                               ;B2E1AC;
@@ -10517,6 +10604,7 @@ UNUSED_Spitemaps_SpacePirate_B2E341:
     dw $611B,$01FB                                                       ;B2E373;
     db $FF                                                               ;B2E377;
     dw $610B                                                             ;B2E378;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_4D:
     dw $0009,$01FC                                                       ;B2E37A;
@@ -10539,6 +10627,7 @@ Spitemaps_PirateNinja_4D:
     db $FE                                                               ;B2E3A6;
     dw $614A                                                             ;B2E3A7;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2E3A9:
     dw $0009,$8005                                                       ;B2E3A9;
     db $00                                                               ;B2E3AD;
@@ -10833,6 +10922,7 @@ UNUSED_Spitemaps_SpacePirate_B2E606:
     dw $6126,$0005                                                       ;B2E647;
     db $15                                                               ;B2E64B;
     dw $6125                                                             ;B2E64C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_4E:
     dw $0012,$81FD                                                       ;B2E64E;
@@ -10920,6 +11010,7 @@ Spitemaps_PirateNinja_4F:
     db $09                                                               ;B2E717;
     dw $A12D                                                             ;B2E718;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2E71A:
     dw $0014,$0000                                                       ;B2E71A;
     db $F2                                                               ;B2E71E;
@@ -11113,6 +11204,7 @@ UNUSED_Spitemaps_SpacePirate_B2E88C:
     dw $6126,$0006                                                       ;B2E8D7;
     db $10                                                               ;B2E8DB;
     dw $6125                                                             ;B2E8DC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Spitemaps_PirateNinja_50:
     dw $0011,$81FD                                                       ;B2E8DE;
@@ -11233,6 +11325,7 @@ Spitemaps_PirateNinja_52:
     db $DA                                                               ;B2E9F4;
     dw $612D                                                             ;B2E9F5;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spitemaps_SpacePirate_B2E9F7:
     dw $0004,$81FA                                                       ;B2E9F7;
     db $00                                                               ;B2E9FB;
@@ -11559,6 +11652,7 @@ UNUSED_Spitemaps_SpacePirate_B2EC9B:
     dw $61B0,$81F7                                                       ;B2ECB9;
     db $EE                                                               ;B2ECBD;
     dw $61A2                                                             ;B2ECBE;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PirateWall_FireLaser_WallJumpLeft:
     dw Instruction_PirateWall_FunctionInY                                ;B2ECC0;
@@ -12311,6 +12405,7 @@ InstList_PirateNinja_Active_FacingLeft_1:
     dw Instruction_Common_GotoY                                          ;B2F248;
     dw InstList_PirateNinja_Active_FacingLeft_1                          ;B2F24A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PirateNinja_WalkingLeft_B2F24C:
     dw $0005                                                             ;B2F24C;
     dw ExtendedSpritemaps_PirateNinja_22                                 ;B2F24E;
@@ -12330,6 +12425,7 @@ UNUSED_InstList_PirateNinja_WalkingLeft_B2F24C:
     dw ExtendedSpritemaps_PirateNinja_29                                 ;B2F26A;
     dw Instruction_Common_GotoY                                          ;B2F26C;
     dw UNUSED_InstList_PirateNinja_WalkingLeft_B2F24C                    ;B2F26E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PirateNinja_Flinch_FacingLeft:
     dw Instruction_PirateWall_FunctionInY                                ;B2F270;
@@ -12440,10 +12536,12 @@ InstList_PirateNinja_Land_FacingLeft_1:
     dw Instruction_Common_GotoY                                          ;B2F324;
     dw InstList_PirateNinja_Land_FacingLeft_1                            ;B2F326;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PirateNinja_FacingForward_B2F328:
     dw $0008                                                             ;B2F328;
     dw ExtendedSpritemaps_PirateNinja_4C                                 ;B2F32A;
     dw Instruction_Common_Sleep                                          ;B2F32C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PirateNinja_StandingKick_FacingLeft:
     dw Instruction_PirateWall_FunctionInY                                ;B2F32E;
@@ -12560,9 +12658,11 @@ InstList_PirateNinja_SpinJumpRight_1:
     dw Instruction_Common_GotoY                                          ;B2F418;
     dw InstList_PirateNinja_SpinJumpRight_1                              ;B2F41A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PirateNinja_B2F41C:
     dw $0010                                                             ;B2F41C;
     dw ExtendedSpritemaps_PirateNinja_9                                  ;B2F41E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PirateNinja_Active_FacingRight_0:
     dw Instruction_PirateWall_FunctionInY                                ;B2F420;
@@ -12583,6 +12683,7 @@ InstList_PirateNinja_Active_FacingRight_1:
     dw Instruction_Common_GotoY                                          ;B2F43A;
     dw InstList_PirateNinja_Active_FacingRight_1                         ;B2F43C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_PirateNinja_WalkingRight_B2F43E:
     dw $0005                                                             ;B2F43E;
     dw ExtendedSpritemaps_PirateNinja_2A                                 ;B2F440;
@@ -12602,6 +12703,7 @@ UNUSED_InstList_PirateNinja_WalkingRight_B2F43E:
     dw ExtendedSpritemaps_PirateNinja_31                                 ;B2F45C;
     dw Instruction_Common_GotoY                                          ;B2F45E;
     dw UNUSED_InstList_PirateNinja_WalkingRight_B2F43E                   ;B2F460;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_PirateNinja_Flinch_FacingRight:
     dw Instruction_PirateWall_FunctionInY                                ;B2F462;
@@ -12752,6 +12854,7 @@ Instruction_PirateNinja_QueueSoundInY_Lib2_Max6:
     RTL                                                                  ;B2F553;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PirateNinja_GotoFunction0FAC_B2F554:
     PHX                                                                  ;B2F554;
     LDX.W $0E54                                                          ;B2F555;
@@ -12761,6 +12864,7 @@ UNUSED_Instruction_PirateNinja_GotoFunction0FAC_B2F554:
     TAY                                                                  ;B2F561;
     PLX                                                                  ;B2F562;
     RTL                                                                  ;B2F563;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PirateNinja_SpawnClawProjWithThrowDirSpawnOffset:
@@ -12810,6 +12914,7 @@ Instruction_PirateNinja_SetFunction0FAC_Active:
     RTL                                                                  ;B2F5B2;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_PirateNinja_Set0FAC_StandingKick_B2F5B3:
     PHX                                                                  ;B2F5B3;
     LDX.W $0E54                                                          ;B2F5B4;
@@ -12829,6 +12934,7 @@ UNUSED_Instruction_PirateNinja_Set0FAC_StandingKick_B2F5B3:
     STA.W $0FAC,X                                                        ;B2F5D1;
     PLX                                                                  ;B2F5D4;
     RTL                                                                  ;B2F5D5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_PirateNinja_ResetSpeed:

--- a/src/bank_B3.asm
+++ b/src/bank_B3.asm
@@ -169,6 +169,7 @@ Instruction_CommonB3_CallFunctionInY_WithA:
     RTL                                                                  ;B380B4;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Instruction_CommonB3_CallExternalFunctionInY_B380B5:
     LDA.W $0000,Y                                                        ;B380B5;
     STA.B $12                                                            ;B380B8;
@@ -209,6 +210,7 @@ UNUSED_Inst_CommonB3_CallExternalFunctionInY_WithA_B380CE:
 
 .externalFunction:
     JML.W [$0012]                                                        ;B380EA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Instruction_CommonB3_GotoY:
@@ -443,6 +445,7 @@ UNUSED_InstList_SpinningTurtleEye_Initial_B386A7:
     dw Instruction_Common_GotoY                                          ;B386C7;
     dw UNUSED_InstList_SpinningTurtleEye_Initial_B386A7                  ;B386C9;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_SpinningTurtleEye_B386CB:
     dw $0008                                                             ;B386CB;
     dw UNUSED_Spritemaps_SpinningTurtleEye_8_B3874C                      ;B386CD;
@@ -472,6 +475,7 @@ UNUSED_InstList_SpinningTurtleEye_B386EB:
     dw UNUSED_Spritemaps_SpinningTurtleEye_10_B38784                     ;B386F5;
     dw Instruction_Common_GotoY                                          ;B386F7;
     dw UNUSED_InstList_SpinningTurtleEye_B386EB                          ;B386F9;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_InitAI_SpinningTurtleEye_B386FB:
     LDX.W $0E54                                                          ;B386FB;
@@ -536,6 +540,7 @@ UNUSED_Spritemaps_SpinningTurtleEye_7_B38745:
     db $F8                                                               ;B38749;
     dw $F303                                                             ;B3874A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_SpinningTurtleEye_8_B3874C:
     dw $0001,$01F8                                                       ;B3874C;
     db $F8                                                               ;B38750;
@@ -580,6 +585,7 @@ UNUSED_Spritemaps_SpinningTurtleEye_10_B38784:
     dw $0001,$01F8                                                       ;B38784;
     db $F8                                                               ;B38788;
     dw $330C                                                             ;B38789;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Zeb:
     dw $3800,$021D,$0015,$0008,$0003,$00BD,$0013,$000E                   ;B3878B;
@@ -1468,9 +1474,11 @@ Function_Gamet_ShootingRight:
     RTS                                                                  ;B38E55;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LoadEnemyIndex_B38E56:
     LDX.W $0E54                                                          ;B38E56;
     RTS                                                                  ;B38E59;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 Function_Gamet_ShootDelay:
@@ -2044,6 +2052,7 @@ Spritemaps_Geega_A:
 Spritemaps_Geega_B:
     db $01,$00,$F8,$C3,$F8,$0A,$61                                       ;B392FA;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpritemapPointers_Geega_B39301:
     dw Spritemaps_Geega_0                                                ;B39301;
     dw Spritemaps_Geega_1                                                ;B39303;
@@ -2057,6 +2066,7 @@ UNUSED_SpritemapPointers_Geega_B39301:
     dw Spritemaps_Geega_9                                                ;B39313;
     dw Spritemaps_Geega_A                                                ;B39315;
     dw Spritemaps_Geega_B                                                ;B39317;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_Botwoon:
     dw $0000,$27E9,$1A66,$1585,$0CA3,$3F9C,$2E97,$1D72                   ;B39319;
@@ -2167,6 +2177,7 @@ InstList_Botwoon_Spit_AimingDownLeft:
     dw Spritemaps_Botwoon_MouthOpen_Priority2_AimingDownLeft             ;B393CB;
     dw Instruction_Common_Sleep                                          ;B393CD;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Botwoon_Spit_AimingDown_FacingLeft_B393CF:
     dw $0020                                                             ;B393CF;
     dw Spritemaps_Botwoon_MouthClosed_Priority2_AimDown_FacingLeft       ;B393D1;
@@ -2176,6 +2187,7 @@ UNUSED_InstList_Botwoon_Spit_AimingDown_FacingLeft_B393CF:
     dw $0010                                                             ;B393D9;
     dw Spritemaps_Botwoon_MouthOpen_Priority2_AimingDown_FacingLeft      ;B393DB;
     dw Instruction_Common_Sleep                                          ;B393DD;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Botwoon_Spit_AimingDown_FacingRight:
     dw $0020                                                             ;B393DF;
@@ -2227,10 +2239,12 @@ InstList_Botwoon_Spit_AimingUp_FacingRight:
     dw Spritemaps_Botwoon_MouthOpen_Priority2_AimingUp_FacingRight       ;B3942B;
     dw Instruction_Common_Sleep                                          ;B3942D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Botwoon_Hidden_AimingUp_FacingLeft_B3942F:
     dw $0001                                                             ;B3942F;
     dw Spritemaps_Botwoon_MouthClosed_Priority0_AimingUp_FacingLeft      ;B39431;
     dw Instruction_Common_Sleep                                          ;B39433;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Botwoon_Hidden_AimingUpLeft:
     dw $0001                                                             ;B39435;
@@ -2247,10 +2261,12 @@ InstList_Botwoon_Hidden_AimingDownLeft:
     dw Spritemaps_Botwoon_MouthClosed_Priority0_AimingDownLeft           ;B39443;
     dw Instruction_Common_Sleep                                          ;B39445;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_Botwoon_Hidden_AimingDown_FacingLeft_B39447:
     dw $0001                                                             ;B39447;
     dw Spritemaps_Botwoon_MouthClosed_Priority0_AimDown_FacingLeft       ;B39449;
     dw Instruction_Common_Sleep                                          ;B3944B;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 InstList_Botwoon_Hidden_AimingDown_FacingRight:
     dw $0001                                                             ;B3944D;
@@ -2530,6 +2546,7 @@ MainAI_Botwoon:
     RTL                                                                  ;B39674;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Data_B39675:
     dw $FFFF,$00FF,$01FF                                                 ;B39675;
 
@@ -2567,6 +2584,7 @@ UNUSED_Botwoon_MaybeSpitting_B39396:
   + LDA.W #$0000                                                         ;B396BE;
     STA.L $7E801C,X                                                      ;B396C1;
     RTS                                                                  ;B396C5;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 BotwoonDeathCheck:
@@ -2596,6 +2614,7 @@ SetBotwoonAsIntangible:
     RTS                                                                  ;B396FE;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SetBotwoonBodyProjectilesAsIntangible_B396FF:
     LDY.W #$0022                                                         ;B396FF;
 
@@ -2611,6 +2630,7 @@ UNUSED_SetBotwoonBodyProjectilesAsIntangible_B396FF:
     CPY.W #$000A                                                         ;B39715;
     BPL .loop                                                            ;B39718;
     RTS                                                                  ;B3971A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 
 BotwoonHealthBasedPalettes:
@@ -5142,6 +5162,7 @@ Spritemaps_Botwoon_MouthClosed_Priority0_AimUp_FacingRight:
     db $E7                                                               ;B3E496;
     dw $4120                                                             ;B3E497;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Spritemaps_Botwoon_MouthOpen_Prio0_UpFaceLeft_B3E499:
     dw $0002,$81F8                                                       ;B3E499;
     db $F8                                                               ;B3E49D;
@@ -5219,6 +5240,7 @@ UNUSED_Spritemaps_Botwoon_MouthOpen_Prio0_UpFaceRight_B3E519:
     dw $4126,$81F8                                                       ;B3E51E;
     db $E8                                                               ;B3E522;
     dw $4124                                                             ;B3E523;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Palette_EtecoonEscape:
     dw $3800,$5F97,$56F2,$2987,$00A0,$6355,$4AB0,$3A0B                   ;B3E525;
@@ -5365,6 +5387,7 @@ Instruction_EtecoonEscape_XPositionPlusY:
     RTL                                                                  ;B3E61C;
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_EtecoonEscape_B3E61D:
     dw $0001                                                             ;B3E61D;
     dw Spritemaps_EtecoonEscape_6                                        ;B3E61F;
@@ -5400,6 +5423,7 @@ UNUSED_InstList_EtecoonEscape_B3E63F:
     dw $000C                                                             ;B3E64F;
     dw Spritemaps_EtecoonEscape_B                                        ;B3E651;
     dw Instruction_Common_Sleep                                          ;B3E653;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 MainAI_EtecoonEscape:
     LDX.W $0E54                                                          ;B3E655;

--- a/src/bank_B4.asm
+++ b/src/bank_B4.asm
@@ -113,11 +113,13 @@ EnemySets_CrateriaMap:
     db $00                                                               ;B480F1;
     db "SF2_14 "                                                         ;B480F2;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B480F9:
     dw EnemyHeaders_FaceBlock                                            ;B480F9;
     dw $0001,$FFFF                                                       ;B480FB;
     db $00                                                               ;B480FF;
     db "SF2_13a"                                                         ;B48100;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_FinalMissile_1:
     dw $FFFF                                                             ;B48107;
@@ -130,10 +132,12 @@ EnemySets_Climb_2:
     db $00                                                               ;B48117;
     db "sf1_03 "                                                         ;B48118;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B4811F:
     dw $FFFF                                                             ;B4811F;
     db $00                                                               ;B48121;
     db "SF1_05 "                                                         ;B48122;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_CrateriaSave:
     dw $FFFF                                                             ;B48129;
@@ -172,10 +176,12 @@ EnemySets_WestOcean:
     db $00                                                               ;B48173;
     db "SF1_20 "                                                         ;B48174;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B4817B:
     dw $FFFF                                                             ;B4817B;
     db $00                                                               ;B4817D;
     db "sf1_02 "                                                         ;B4817E;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_Parlor_0:
     dw EnemyHeaders_Sbug                                                 ;B48185;
@@ -199,10 +205,12 @@ EnemySets_CrateriaSuper:
     db $00                                                               ;B481AF;
     db "SF1_19 "                                                         ;B481B0;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B481B7:
     dw $FFFF                                                             ;B481B7;
     db $00                                                               ;B481B9;
     db "SF1_18 "                                                         ;B481BA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_PreBowling:
     dw EnemyHeaders_HZoomer                                              ;B481C1;
@@ -547,10 +555,12 @@ EnemySets_RedBrinstarSave:
     db $00                                                               ;B484A5;
     db "BL1_24a"                                                         ;B484A6;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B484AD:
     dw $FFFF                                                             ;B484AD;
     db $00                                                               ;B484AF;
     db "BL1_16 "                                                         ;B484B0;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_BlueBrinstarETank_0:
     dw EnemyHeaders_Eye                                                  ;B484B7;
@@ -598,10 +608,12 @@ EnemySets_WarehouseETank:
     db $00                                                               ;B48517;
     db "BL2_20a"                                                         ;B48518;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B4851F:
     dw $FFFF                                                             ;B4851F;
     db $00                                                               ;B48521;
     db "BL2_20 "                                                         ;B48522;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_WarehouseEntrance:
     dw $FFFF                                                             ;B48529;
@@ -1003,10 +1015,12 @@ EnemySets_MagdolliteTunnel:
     db $00                                                               ;B48891;
     db "NO2_08 "                                                         ;B48892;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_State8FB3EE_B48899:
     dw $FFFF                                                             ;B48899;
     db $00                                                               ;B4889B;
     db "NO1_37 "                                                         ;B4889C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_LavaDive:
     dw EnemyHeaders_Namihe                                               ;B488A3;
@@ -2075,6 +2089,7 @@ EnemySets_TourianRecharge:
     db $00                                                               ;B491D0;
     db "TS1_07 "                                                         ;B491D1;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemySets_B491D8:
     dw EnemyHeaders_CorpseSidehopper                                     ;B491D8;
     dw $0001                                                             ;B491DA;
@@ -2084,6 +2099,7 @@ UNUSED_EnemySets_B491D8:
     dw $0001,$FFFF                                                       ;B491E2;
     db $00                                                               ;B491E6;
     db "TS1_18 "                                                         ;B491E7;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemySets_UpperTourianSave:
     dw $FFFF                                                             ;B491EE;
@@ -4649,6 +4665,7 @@ DebugSpritemaps_13_F:
     db $F8                                                               ;B4A89C;
     dw $30DF                                                             ;B4A89D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DebugSpritemaps_a_B4A89F:
     dw $0001,$01F8                                                       ;B4A89F;
     db $F8                                                               ;B4A8A3;
@@ -4693,6 +4710,7 @@ UNUSED_DebugSpritemaps_i_B4A8D7:
     dw $0001,$01F8                                                       ;B4A8D7;
     db $F8                                                               ;B4A8DB;
     dw $30E8                                                             ;B4A8DC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 DebugSpritemaps_1D_j:
     dw $0001,$01F8                                                       ;B4A8DE;
@@ -4939,6 +4957,7 @@ DebugSpritemaps_27_EnemyDebuggerText_PosX_PosY_HP_Pointer:
     db $E0                                                               ;B4AB03;
     dw $30C5                                                             ;B4AB04;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_DebugSpritemaps_PosX_PosY_HP_B4AB06:
     dw $001E,$0018                                                       ;B4AB06;
     db $F8                                                               ;B4AB0A;
@@ -5001,6 +5020,7 @@ UNUSED_DebugSpritemaps_PosX_PosY_HP_B4AB06:
     dw $30CC,$01E0                                                       ;B4AB97;
     db $E0                                                               ;B4AB9B;
     dw $30C1                                                             ;B4AB9C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_DebugSpritemaps_28_EnemyIndicator_B4AB9E:
     dw $0008,$0018                                                       ;B4AB9E;
@@ -7252,6 +7272,7 @@ InstList_SpriteObject_3D_DraygonFoamingAtTheMouth:
     dw SpriteObjectSpritemaps_3D_DraygonFoamingAtTheMouth_7              ;B4BE42;
     dw Instruction_SpriteObject_Delete                                   ;B4BE44;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_InstList_SpriteObject_B4BE46:
     dw $0005                                                             ;B4BE46;
     dw UNUSED_SpriteObjectSpritemaps_B4DD3C                              ;B4BE48;
@@ -7260,6 +7281,7 @@ UNUSED_InstList_SpriteObject_B4BE46:
     dw $0005                                                             ;B4BE4E;
     dw UNUSED_SpriteObjectSpritemaps_B4DD4A                              ;B4BE50;
     dw Instruction_SpriteObject_Delete                                   ;B4BE52;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_InstList_SpriteObject_2F_B4BE54:
     dw $0001                                                             ;B4BE54;
@@ -9505,6 +9527,7 @@ SpriteObjectSpritemaps_C_Smoke_3:
     db $F0                                                               ;B4CE06;
     dw $3A9E                                                             ;B4CE07;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4CE09:
     dw $0001,$01FC                                                       ;B4CE09;
     db $FC                                                               ;B4CE0D;
@@ -9519,6 +9542,7 @@ UNUSED_SpriteObjectSpritemaps_B4CE17:
     dw $0001,$01FC                                                       ;B4CE17;
     db $FC                                                               ;B4CE1B;
     dw $3A40                                                             ;B4CE1C;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_SpriteObjectSpritemaps_D_SmallEnergyDrop_0_B4CE1E:
     dw $0001,$01FC                                                       ;B4CE1E;
@@ -9598,6 +9622,7 @@ UNUSED_SpriteObjectSpritemaps_F_Bomb_3_B4CE98:
     db $FC                                                               ;B4CE9C;
     dw $3A4F                                                             ;B4CE9D;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4CE9F:
     dw $0002,$01FF                                                       ;B4CE9F;
     db $FC                                                               ;B4CEA3;
@@ -9725,6 +9750,7 @@ UNUSED_SpriteObjectSpritemaps_B4CF76:
     dw $BA67,$01FA                                                       ;B4CF80;
     db $02                                                               ;B4CF84;
     dw $BA66                                                             ;B4CF85;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_SpriteObjectSpritemaps_10_SmallEnergyDrop_0_B4CF87:
     dw $0001,$01FC                                                       ;B4CF87;
@@ -9741,10 +9767,12 @@ UNUSED_SpriteObjectSpritemaps_10_SmallEnergyDrop_2_B4CF95:
     db $FC                                                               ;B4CF99;
     dw $3A3E                                                             ;B4CF9A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4CF9C:
     dw $0001,$01FC                                                       ;B4CF9C;
     db $FC                                                               ;B4CFA0;
     dw $3A3F                                                             ;B4CFA1;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SpriteObjectSpritemaps_1D_BigExplosion_0:
     dw $0004,$0000                                                       ;B4CFA3;
@@ -9978,6 +10006,7 @@ UNUSED_SpriteObjectSpritemaps_26_5_B4D176:
     db $08                                                               ;B4D1A2;
     dw $20F5                                                             ;B4D1A3;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4D1A5:
     dw $0009,$81FE                                                       ;B4D1A5;
     db $FB                                                               ;B4D1A9;
@@ -9998,6 +10027,7 @@ UNUSED_SpriteObjectSpritemaps_B4D1A5:
     dw $20F6,$01FE                                                       ;B4D1CD;
     db $08                                                               ;B4D1D1;
     dw $20F5                                                             ;B4D1D2;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_SpriteObjectSpritemaps_27_0_B4D1D4:
     dw $0005,$0000                                                       ;B4D1D4;
@@ -10062,6 +10092,7 @@ UNUSED_SpriteObjectSpritemaps_27_4_B4D245:
     db $FC                                                               ;B4D253;
     dw $20F4                                                             ;B4D254;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4D256:
     dw $0006,$01FE                                                       ;B4D256;
     db $F4                                                               ;B4D25A;
@@ -10102,6 +10133,7 @@ UNUSED_SpriteObjectSpritemaps_B4D296:
     dw $20F8,$01F8                                                       ;B4D2A5;
     db $F8                                                               ;B4D2A9;
     dw $20F7                                                             ;B4D2AA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_SpriteObjectSpritemaps_2A_B4D2AC:
     dw $0001,$81F8                                                       ;B4D2AC;
@@ -10234,6 +10266,7 @@ UNUSED_SpriteObjectSpritemaps_28_5_B4D39E:
     db $08                                                               ;B4D3CA;
     dw $60F5                                                             ;B4D3CB;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4D3CD:
     dw $0009,$81F2                                                       ;B4D3CD;
     db $FB                                                               ;B4D3D1;
@@ -10254,6 +10287,7 @@ UNUSED_SpriteObjectSpritemaps_B4D3CD:
     dw $60F6,$01FA                                                       ;B4D3F5;
     db $08                                                               ;B4D3F9;
     dw $60F5                                                             ;B4D3FA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 UNUSED_SpriteObjectSpritemaps_29_0_B4D3FC:
     dw $0005,$01F8                                                       ;B4D3FC;
@@ -10318,6 +10352,7 @@ UNUSED_SpriteObjectSpritemaps_29_4_B4D46D:
     db $F4                                                               ;B4D47B;
     dw $60F4                                                             ;B4D47C;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4D47E:
     dw $0006,$01FA                                                       ;B4D47E;
     db $F4                                                               ;B4D482;
@@ -10347,6 +10382,7 @@ UNUSED_SpriteObjectSpritemaps_B4D49E:
     dw $60F1,$01FE                                                       ;B4D4B7;
     db $FC                                                               ;B4D4BB;
     dw $60F0                                                             ;B4D4BC;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SpriteObjectSpritemaps_2B_Puromi_0:
     dw $0001,$81F9                                                       ;B4D4BE;
@@ -11173,6 +11209,7 @@ UNUSED_SpriteObjectSpritemaps_3A_7_B4DAD8:
     db $07                                                               ;B4DB22;
     dw $20F5                                                             ;B4DB23;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4FB25:
     dw $0004,$0000                                                       ;B4DB25;
     db $00                                                               ;B4DB29;
@@ -11188,6 +11225,7 @@ UNUSED_SpriteObjectSpritemaps_B4FB3B:
     dw $0001,$81F8                                                       ;B4DB3B;
     db $F8                                                               ;B4DB3F;
     dw $20DE                                                             ;B4DB40;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SpriteObjectSpritemaps_3B_EvirFacingLeft_0:
     dw $000C,$0000                                                       ;B4DB42;
@@ -11409,6 +11447,7 @@ SpriteObjectSpritemaps_3C_EvirFacingRight_3:
     db $06                                                               ;B4DD39;
     dw $60F5                                                             ;B4DD3A;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_SpriteObjectSpritemaps_B4DD3C:
     dw $0001,$81F8                                                       ;B4DD3C;
     db $F8                                                               ;B4DD40;
@@ -11423,6 +11462,7 @@ UNUSED_SpriteObjectSpritemaps_B4DD4A:
     dw $0001,$81F8                                                       ;B4DD4A;
     db $F8                                                               ;B4DD4E;
     dw $3BCE                                                             ;B4DD4F;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 SpriteObjectSpritemaps_3D_DraygonFoamingAtTheMouth_0:
     dw $0001,$81F8                                                       ;B4DD51;
@@ -12708,6 +12748,7 @@ EnemyVulnerabilities_Kago:
     db $00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$02   ;B4F026;
     db $00,$00,$00,$00,$00,$00                                           ;B4F036;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyVulnerabilities_B4F03C:
     db $00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$02   ;B4F03C;
     db $00,$00,$00,$02,$00,$00                                           ;B4F04C;
@@ -12715,6 +12756,7 @@ UNUSED_EnemyVulnerabilities_B4F03C:
 UNUSED_EnemyVulnerabilities_B4F052:
     db $00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$00,$04   ;B4F052;
     db $00,$00,$00,$02,$00,$00                                           ;B4F062;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyVulnerabilities_Zebetite:
     db $80,$80,$80,$80,$80,$80,$80,$80,$80,$80,$80,$80,$82,$82,$80,$80   ;B4F068;
@@ -12728,9 +12770,11 @@ EnemyVulnerabilities_SporeSpawn:
     db $80,$82,$82,$82,$80,$82,$82,$82,$82,$82,$82,$82,$82,$82,$80,$80   ;B4F094;
     db $80,$80,$80,$04,$80,$80                                           ;B4F0A4;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyVulnerabilities_B4F0AA:
     db $82,$82,$82,$82,$82,$82,$82,$82,$82,$82,$82,$82,$82,$82,$82,$82   ;B4F0AA;
     db $82,$82,$82,$02,$82,$82                                           ;B4F0BA;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyVulnerabilities_BombTorizo_BombTorizoOrb:
     db $02,$02,$82,$82,$02,$02,$82,$82,$02,$02,$82,$82,$02,$04,$00,$00   ;B4F0C0;
@@ -13001,8 +13045,10 @@ EnemyDropChances_Metroid:
 EnemyDropChances_Rinka:
     db $00,$00,$00,$FF,$00,$00                                           ;B4F374;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyDropChances_B4F37A:
     db $00,$82,$3C,$05,$1E,$1E                                           ;B4F37A;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyDropChances_Bang:
     db $2D,$50,$50,$1E,$0A,$0A                                           ;B4F380;
@@ -13142,8 +13188,10 @@ EnemyDropChances_Steam_Dachora_DachoraEscape:
 EnemyDropChances_Polyp:
     db $00,$00,$00,$FF,$00,$00                                           ;B4F48E;
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_EnemyDropChances_B4F494:
     db $00,$00,$00,$FF,$00,$00                                           ;B4F494;
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 EnemyDropChances_MotherBrainHead:
     db $00,$00,$00,$FF,$00,$00                                           ;B4F49A;

--- a/src/bank_B9..CE.asm
+++ b/src/bank_B9..CE.asm
@@ -654,8 +654,10 @@ incbin "../data/LevelData_Kraid.bin" ; $26D bytes
 LevelData_StatuesHallway:
 incbin "../data/LevelData_StatuesHallway.bin" ; $4EA bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LevelData_C6DD77:
 incbin "../data/UNUSED_LevelData_C6DD77.bin" ; $169 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LevelData_WarehouseEntrance:
 incbin "../data/LevelData_WarehouseEntrance.bin" ; $475 bytes
@@ -804,8 +806,10 @@ incbin "../data/LevelData_RedPirateShaft.bin" ; $36E bytes
 LevelData_AcidStatue:
 incbin "../data/LevelData_AcidStatue.bin" ; $8D6 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LevelData_C8CDA9:
 incbin "../data/UNUSED_LevelData_C8CDA9.bin" ; $7F3 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LevelData_MainHall:
 incbin "../data/LevelData_MainHall.bin" ; $B01 bytes
@@ -825,8 +829,10 @@ incbin "../data/LevelData_LNFarming.bin" ; $251 bytes
 LevelData_FastPillarsSetup:
 incbin "../data/LevelData_FastPillarsSetup.bin" ; $3EC bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LevelData_C8F40B:
 incbin "../data/UNUSED_LevelData_C8F40B.bin" ; $180 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LevelData_MickeyMouse:
 incbin "../data/LevelData_MickeyMouse.bin" ; $73A bytes
@@ -1122,8 +1128,10 @@ incbin "../data/LevelData_SaveStation_BothDoors.bin" ; $30B bytes
 LevelData_RefillStation_LeftSideDoor:
 incbin "../data/LevelData_RefillStation_LeftSideDoor.bin" ; $302 bytes
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_LevelData_CEA503:
 incbin "../data/UNUSED_LevelData_CEA503.bin" ; $320 bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 LevelData_RefillStation_RightSideDoor:
 incbin "../data/LevelData_RefillStation_RightSideDoor.bin" ; $30E bytes

--- a/src/bank_DF.asm
+++ b/src/bank_DF.asm
@@ -2,8 +2,10 @@
 org $DF8000
 
 
+if !FEATURE_KEEP_UNREFERENCED
 UNUSED_Music_DF8000:
 incbin "../data/UNUSED_Music_DF8000.bin" ; $54DE bytes
+endif ; !FEATURE_KEEP_UNREFERENCED
 
 Freespace_BankDF_D4DF:                                                   ;DFD4DF;
 ; $2B21 bytes

--- a/src/main.asm
+++ b/src/main.asm
@@ -2,6 +2,20 @@
 lorom
 math pri on
 
+; -------------
+; Build options
+; -------------
+
+; Defaults will build vanilla Super Metroid.sfc
+
+!FEATURE_KEEP_UNREFERENCED ?= 1
+
+if !FEATURE_KEEP_UNREFERENCED
+    print "KEEP UNREFERENCED ASSEMBLY"
+else
+    print "REMOVE UNREFERENCED ASSEMBLY"
+endif
+
 incsrc "macros.asm"
 incsrc "bank_80.asm"
 incsrc "bank_81.asm"
@@ -59,3 +73,5 @@ incsrc "bank_B8.asm"
 incsrc "bank_B9..CE.asm"
 incsrc "bank_CF..DE.asm"
 incsrc "bank_DF.asm"
+
+print "Assembly complete. Total bytes written: ", bytes

--- a/test_build.bat
+++ b/test_build.bat
@@ -1,17 +1,18 @@
 
 @echo off
 
+set "sfc_src=Super Metroid.sfc"
+if "%~1" neq "" set "sfc_src=%~1"
+
 echo Creating FF file
 python tools/ff_file.py ../SM.sfc
 
 echo Patching FF file with asar
-cd tools
-set START=%TIME%
-asar --no-title-check --symbols=wla --symbols-path=../symbols.sym ../src/main.asm ../SM.sfc
-set END=%TIME%
+set START=%TIME: =0%
+"tools/asar" --no-title-check --symbols=wla --symbols-path=symbols.sym src/main.asm SM.sfc
+set END=%TIME: =0%
 
-cd ..
-fc "SM.sfc" "Super Metroid.sfc"
+fc SM.sfc "%sfc_src%"
 if errorlevel 1 goto error
 
 echo Success! This ROM matches vanilla Super Metroid
@@ -43,10 +44,10 @@ rem Output
 echo DURATION: %DURATION% in centiseconds
 
 endlocal
-
-PAUSE
-exit
+goto done
 
 :error
 echo !! FILE MISMATCH !!
+
+:done
 PAUSE


### PR DESCRIPTION
I search for "unused" assembly and if the assembly was also unreferenced then I marked it unreferenced.  By default, keep unreferenced assembly is enabled.  Disabling this saves 92182 bytes.  I also updated build scripts to support passing in options (e.g. -DFEATURE_KEEP_UNREFERENCED=0) and also if your Super Metroid.sfc has a different name (e.g. Super Metroid NTSC.sfc).

Disclaimers:
- This is just a first pass.  It may contain errors or make incorrect assumptions in either direction (unreferenced code might not be marked and also necessary code might be marked as unreferenced; I only verified the assembly builds).
- While the long term goal of sm_disassembly is to be relocatable, we aren't there yet.  Removing unreferenced code will cause some code to be relocated which may break logic.
- In grey area situations, I usually considered the assembly referenced.  This could be further refined.

Some grey area examples:
- Unused entries in a jump table.  In game glitch scenarios perhaps those jumps will be taken, and also the jump table entries are still needed (we could replace the values with 0000 or some other value but some value needs to be there).
- Logic for an enemy that does exist but is never used in a vanilla room or enemy set.
- A draw instruction for 0000 cycles.
- Instructions where it was not immediately obvious that they will not be executed.